### PR TITLE
Upgrade code to use modern C#

### DIFF
--- a/Gradio.Net/App.cs
+++ b/Gradio.Net/App.cs
@@ -1,293 +1,282 @@
-﻿
-using Gradio.Net;
-using Gradio.Net.Models;
+﻿using Gradio.Net.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.StaticFiles;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Text.Json;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class App
 {
-    public class App
+    const string GRADIO_VERSION = "4.29.0";
+    private readonly long _appId;
+
+    public static void Launch(Blocks blocks, Action<GradioServiceConfig>? additionalConfigurationAction = null, params string[] args)
     {
-        const string GRADIO_VERSION = "4.29.0";
-        private readonly long _appId;
+        WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+        builder.Services.AddGradio();
 
-        public static void Launch(Blocks blocks, Action<GradioServiceConfig>? additionalConfigurationAction = null, params string[] args)
+        WebApplication app = builder.Build();
+
+        app.UseGradio(blocks, additionalConfigurationAction);
+
+        app.Run();
+    }
+
+    private GradioServiceConfig _gradioServiceConfig;
+
+    internal App()
+    {
+        this._appId = new Random(DateTime.Now.Millisecond).NextInt64();
+    }
+
+    internal Dictionary<string, object> GetConfig(HttpRequest httpRequest)
+    {
+        Dictionary<string, object> result = Context.RootBlock.GetConfig();
+
+        result["root"] = httpRequest.GetRootUrl();
+        result["version"] = GRADIO_VERSION;
+        result["app_id"] = _appId;
+        return result;
+    }
+
+    internal void SetConfig(GradioServiceConfig gradioServiceConfig)
+    {
+        this._gradioServiceConfig = gradioServiceConfig;
+    }
+
+
+    internal object GetApiInfo(HttpRequest request)
+    {
+        Dictionary<string, object> result = new()
         {
-            var builder = WebApplication.CreateBuilder(args);
-            builder.Services.AddGradio();
+            ["named_endpoints"] = new Dictionary<string, object>(),
+            ["unnamed_endpoints"] = new Dictionary<string, object>()
+        };
+        return result;
+    }
 
-            var app = builder.Build();
+    internal async Task<QueueJoinOut> QueueJoin(HttpRequest request, PredictBodyIn body)
+    {
+        Event eventIn = new()
+        {
+            RootUrl = request.GetRootUrl(),
+            SessionHash = body.SessionHash,
+            FnIndex = body.FnIndex,
+            ConcurrencyId = Context.RootBlock.Fns[body.FnIndex].ConcurrencyId,
+        };
+        eventIn.Data = body;
 
-            app.UseGradio(blocks, additionalConfigurationAction);
+        await Context.EventChannel.Writer.WriteAsync(eventIn);
 
-            app.Run();
+        return new QueueJoinOut { EventId = eventIn.Id };
+    }
+
+    internal async IAsyncEnumerable<SSEMessage> QueueData(string sessionHash, CancellationToken stoppingToken)
+    {
+        if (string.IsNullOrEmpty(sessionHash))
+        {
+            yield return new UnexpectedErrorMessage("Session not found");
+
+            yield break;
         }
 
-        private GradioServiceConfig _gradioServiceConfig;
-
-        internal App()
+        const int heartbeatRate = 15;
+        const int checkRate = 500;
+        EventResult eventResult = null;
+        int heartbeatCount = 0;
+        while (!stoppingToken.IsCancellationRequested)
         {
-            this._appId = new Random(DateTime.Now.Millisecond).NextInt64();
-        }
-
-        internal Dictionary<string, object> GetConfig(HttpRequest httpRequest)
-        {
-            var result = Context.RootBlock.GetConfig();
-
-            result["root"] = httpRequest.GetRootUrl();
-            result["version"] = GRADIO_VERSION;
-            result["app_id"] = _appId;
-            return result;
-        }
-
-        internal void SetConfig(GradioServiceConfig gradioServiceConfig)
-        {
-            this._gradioServiceConfig = gradioServiceConfig;
-        }
-
-
-        internal object GetApiInfo(HttpRequest request)
-        {
-            var result = new Dictionary<string, object>();
-
-            result["named_endpoints"] = new Dictionary<string, object>();
-            result["unnamed_endpoints"] = new Dictionary<string, object>();
-            return result;
-        }
-
-        internal async Task<QueueJoinOut> QueueJoin(HttpRequest request, PredictBodyIn body)
-        {
-            var eventIn = new Event()
+            await Task.Delay(checkRate);
+            if (Context.EventResults.TryGetValue(sessionHash, out eventResult))
             {
-                RootUrl = request.GetRootUrl(),
-                SessionHash = body.SessionHash,
-                FnIndex = body.FnIndex,
-                ConcurrencyId = Context.RootBlock.Fns[body.FnIndex].ConcurrencyId,
-            };
-            eventIn.Data = body;
-
-            await Context.EventChannel.Writer.WriteAsync(eventIn);
-
-            return new QueueJoinOut { EventId = eventIn.Id };
-        }
-
-        internal async IAsyncEnumerable<SSEMessage> QueueData(string sessionHash, CancellationToken stoppingToken)
-        {
-            if (string.IsNullOrEmpty(sessionHash))
-            {
-                yield return new UnexpectedErrorMessage("Session not found");
-
-                yield break;
+                Context.EventResults.Remove(sessionHash, out _);
+                break;
             }
 
-            const int heartbeatRate = 15;
-            const int checkRate = 500;
-            EventResult eventResult = null;
-            int heartbeatCount = 0;
+            if (heartbeatCount++ > heartbeatRate)
+            {
+                break;
+            }
+
+            yield return new HeartbeatMessage();
+        }
+
+        if (eventResult == null || (eventResult.OutputTask==null && eventResult.StreamingOutputTask == null))
+        {
+            yield return new UnexpectedErrorMessage("no task for Session");
+
+            yield break;
+        }
+
+        if (eventResult.OutputTask != null)
+        {
             while (!stoppingToken.IsCancellationRequested)
             {
-                await Task.Delay(checkRate);
-                if (Context.EventResults.TryGetValue(sessionHash, out eventResult))
+                while (!eventResult.OutputTask.IsCompleted)
                 {
-                    Context.EventResults.Remove(sessionHash, out _);
-                    break;
-                }
-
-                if (heartbeatCount++ > heartbeatRate)
-                {
-                    break;
-                }
-
-                yield return new HeartbeatMessage();
-            }
-
-            if (eventResult == null || (eventResult.OutputTask==null && eventResult.StreamingOutputTask == null))
-            {
-                yield return new UnexpectedErrorMessage("no task for Session");
-
-                yield break;
-            }
-
-            if (eventResult.OutputTask != null)
-            {
-                while (!stoppingToken.IsCancellationRequested)
-                {
-                    while (!eventResult.OutputTask.IsCompleted)
+                    if (eventResult.Input.Progress != null)
                     {
-                        if (eventResult.Input.Progress != null)
-                        {
-                            yield return new ProgressMessage(eventResult.Event.Id, eventResult.Input.Progress);
-                        }
-                        else
-                        {
-                            yield return new HeartbeatMessage();
-                        }
-                        await Task.Delay(checkRate);
-                    }
-
-                    break;
-                }
-
-                if (eventResult.OutputTask.Exception != null)
-                {
-                    Exception ex = eventResult.OutputTask.Exception;
-                    while (ex.InnerException != null)
-                    {
-                        ex = ex.InnerException;
-                    }
-
-                    yield return new UnexpectedErrorMessage(ex.Message);
-
-                    yield break;
-                }
-
-                if (stoppingToken.IsCancellationRequested || !eventResult.OutputTask.IsCompletedSuccessfully)
-                {
-                    yield return new UnexpectedErrorMessage("Task Cancelled");
-
-                    yield break;
-                }
-                var result = eventResult.OutputTask.Result;
-
-                if (result is ErrorOutput error)
-                {
-                    yield return new UnexpectedErrorMessage(error.Exception.Message);
-
-                    yield break;
-                }
-
-                var data = result.Data;
-
-                yield return new ProcessCompletedMessage(eventResult.Event.Id, new Dictionary<string, object> {
-                    { "data",gr.Output(eventResult,data)}
-                });
-                yield break;
-            }
-            else if (eventResult.StreamingOutputTask != null)
-            {
-                yield return new ProcessStartsMessage(eventResult.Event.Id);
-
-                object[] result=null;
-                await foreach (var output in  eventResult.StreamingOutputTask)
-                {
-                    if (stoppingToken.IsCancellationRequested)
-                    {
-                        yield return new UnexpectedErrorMessage("Task Cancelled");
-
-                        yield break;
-                    }
-                    
-                    var outputData = output.Data;
-                    if (result == null)
-                    {
-                        result = gr.Output(eventResult, outputData);
-                        yield return new ProcessGeneratingMessage(eventResult.Event.Id, new Dictionary<string, object> {
-                            { "data",result}
-                        });
+                        yield return new ProgressMessage(eventResult.Event.Id, eventResult.Input.Progress);
                     }
                     else
                     {
-                        var oldResult = result;
-                        result = gr.Output(eventResult, outputData);
-                        var diffResult = new object[result.Length];
-                        for (var i = 0; i < result.Length; i++)
-                        {
-                            if (oldResult[i] != null && result[i] != null  && oldResult[i] is string oldStr  && result[i] is string str && oldStr==str)
-                            {
-                                diffResult[i] = new object[0];
-                            }
-                            else
-                            {
-                                diffResult[i] = new object[] { new List<object> { "replace", new object[0], result[i] } };
-                            }
-                            
-                        }
-                        yield return new ProcessGeneratingMessage(eventResult.Event.Id, new Dictionary<string, object> {
-                            { "data", diffResult}
-                        });
+                        yield return new HeartbeatMessage();
                     }
+                    await Task.Delay(checkRate);
                 }
-                if (result == null)
+
+                break;
+            }
+
+            if (eventResult.OutputTask.Exception != null)
+            {
+                Exception ex = eventResult.OutputTask.Exception;
+                while (ex.InnerException != null)
+                {
+                    ex = ex.InnerException;
+                }
+
+                yield return new UnexpectedErrorMessage(ex.Message);
+
+                yield break;
+            }
+
+            if (stoppingToken.IsCancellationRequested || !eventResult.OutputTask.IsCompletedSuccessfully)
+            {
+                yield return new UnexpectedErrorMessage("Task Cancelled");
+
+                yield break;
+            }
+            Output result = eventResult.OutputTask.Result;
+
+            if (result is ErrorOutput error)
+            {
+                yield return new UnexpectedErrorMessage(error.Exception.Message);
+
+                yield break;
+            }
+
+            object[] data = result.Data;
+
+            yield return new ProcessCompletedMessage(eventResult.Event.Id, new Dictionary<string, object> {
+                { "data",gr.Output(eventResult,data)}
+            });
+            yield break;
+        }
+        else if (eventResult.StreamingOutputTask != null)
+        {
+            yield return new ProcessStartsMessage(eventResult.Event.Id);
+
+            object[] result=null;
+            await foreach (Output output in  eventResult.StreamingOutputTask)
+            {
+                if (stoppingToken.IsCancellationRequested)
                 {
                     yield return new UnexpectedErrorMessage("Task Cancelled");
 
                     yield break;
                 }
 
-
-                yield return new ProcessCompletedMessage(eventResult.Event.Id, new Dictionary<string, object> {
-                    { "data",result}
-                });
-                yield break;
-            }
-            else
-            {
-                yield return new UnexpectedErrorMessage("no task for Session");
-
-                yield break;
-            }
-        }
-
-        internal async Task<List<string>> Upload(string uploadId, IFormFileCollection files)
-        {
-            if (files == null || files.Count == 0)
-            {
-                throw new ArgumentException("No files uploaded.");
-            }
-
-            var outputFiles = new List<string>();
-            var filesToCopy = new List<string>();
-            var locations = new List<string>();
-
-            foreach (var file in files)
-            {
-                if (file.Length == 0)
+                object[] outputData = output.Data;
+                if (result == null)
                 {
-                    continue;
+                    result = gr.Output(eventResult, outputData);
+                    yield return new ProcessGeneratingMessage(eventResult.Event.Id, new Dictionary<string, object> {
+                        { "data",result}
+                    });
                 }
-
-                var fileName = Path.GetFileName(file.FileName);
-                var name = Path.GetInvalidFileNameChars().Aggregate(fileName, (current, c) => current.Replace(c.ToString(), ""));
-                var directory = Path.Combine(Path.GetTempPath(), file.GetHashCode().ToString());
-                Directory.CreateDirectory(directory);
-                var dest = Path.Combine(directory, name);
-
-                using (var stream = new FileStream(dest, FileMode.Create))
+                else
                 {
-                    await file.CopyToAsync(stream);
-                }
-
-                Context.DownloadableFiles.TryAdd(dest,dest);
-
-                outputFiles.Add(dest);
-            }
-
-            return outputFiles;
-        }
-
-        internal async Task<(string filePath, string contentType)> GetUploadedFile(string pathOrUrl)
-        {
-            var filePath = new FileInfo(System.Net.WebUtility.UrlDecode(pathOrUrl)).FullName;
-            if (!Context.DownloadableFiles.TryGetValue(filePath, out _))
-            {
-                throw new ArgumentException($"File not allowed: {pathOrUrl}.");
-            }
-
-            Context.DownloadableFiles.Remove(filePath, out _);
+                    object[] oldResult = result;
+                    result = gr.Output(eventResult, outputData);
+                    object[] diffResult = new object[result.Length];
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        if (oldResult[i] != null && result[i] != null  && oldResult[i] is string oldStr  && result[i] is string str && oldStr==str)
+                        {
+                            diffResult[i] = Array.Empty<object>();
+                        }
+                        else
+                        {
+                            diffResult[i] = new object[] { new List<object> { "replace", Array.Empty<object>(), result[i] } };
+                        }
                         
-            
+                    }
+                    yield return new ProcessGeneratingMessage(eventResult.Event.Id, new Dictionary<string, object> {
+                        { "data", diffResult}
+                    });
+                }
+            }
+            if (result == null)
+            {
+                yield return new UnexpectedErrorMessage("Task Cancelled");
+
+                yield break;
+            }
 
 
-            return (filePath, ClientUtils.GetMimeType(filePath));
+            yield return new ProcessCompletedMessage(eventResult.Event.Id, new Dictionary<string, object> {
+                { "data",result}
+            });
+            yield break;
         }
+        else
+        {
+            yield return new UnexpectedErrorMessage("no task for Session");
+
+            yield break;
+        }
+    }
+
+    internal async Task<List<string>> Upload(string uploadId, IFormFileCollection files)
+    {
+        if (files == null || files.Count == 0)
+        {
+            throw new ArgumentException("No files uploaded.");
+        }
+
+        List<string> outputFiles = [];
+        List<string> filesToCopy = [];
+        List<string> locations = [];
+
+        foreach (IFormFile file in files)
+        {
+            if (file.Length == 0)
+            {
+                continue;
+            }
+
+            string fileName = Path.GetFileName(file.FileName);
+            string name = Path.GetInvalidFileNameChars().Aggregate(fileName, (current, c) => current.Replace(c.ToString(), ""));
+            string directory = Path.Combine(Path.GetTempPath(), file.GetHashCode().ToString());
+            Directory.CreateDirectory(directory);
+            string dest = Path.Combine(directory, name);
+
+            using (FileStream stream = new(dest, FileMode.Create))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            Context.DownloadableFiles.TryAdd(dest,dest);
+
+            outputFiles.Add(dest);
+        }
+
+        return outputFiles;
+    }
+
+    internal async Task<(string filePath, string contentType)> GetUploadedFile(string pathOrUrl)
+    {
+        string filePath = new FileInfo(System.Net.WebUtility.UrlDecode(pathOrUrl)).FullName;
+        if (!Context.DownloadableFiles.TryGetValue(filePath, out _))
+        {
+            throw new ArgumentException($"File not allowed: {pathOrUrl}.");
+        }
+
+        Context.DownloadableFiles.Remove(filePath, out _);
+                    
+        
+
+
+        return (filePath, ClientUtils.GetMimeType(filePath));
     }
 }

--- a/Gradio.Net/BlockFunction.cs
+++ b/Gradio.Net/BlockFunction.cs
@@ -1,83 +1,79 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.AspNetCore.Identity.UI.Services;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using FnTarget = (int? Id, string EventName);
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class BlockFunction
 {
-    internal class BlockFunction
+    internal bool Preprocess { get;  set; }
+    internal bool ShowApi { get;  set; }
+    internal bool ScrollToOutput { get;  set; }
+    internal bool? Queue { get;  set; }
+    internal bool TriggerOnlyOnSuccess { get;  set; }
+    internal int? TriggerAfter { get;  set; }
+    internal bool? CollectsEventData { get;  set; }
+    internal IEnumerable<int> Cancels { get;  set; }
+    internal decimal? Every { get;  set; }
+    internal bool TracksProgress { get;  set; }
+    internal string ConcurrencyId { get;  set; }
+    internal ConcurrencyLimit? ConcurrencyLimit { get;  set; }
+    internal bool Batch { get;  set; }
+    internal bool InputsAsDict { get;  set; }
+    internal bool Postprocess { get;  set; }
+    internal Func<Input,Task<Output>>? Fn { get;  set; }
+    internal Func<Input,IAsyncEnumerable<Output>>? StreamingFn { get; set; }
+    internal string? Js { get;  set; }
+    internal bool TypesContinuous { get;  set; }
+    internal bool TypesGenerator { get;  set; }
+    internal bool ZeroGpu { get; set; }
+    internal TriggerMode? TriggerMode { get; set; }
+    internal int MaxBatchSize { get; set; } = 4;
+    internal ShowProgress ShowProgress { get; set; } = ShowProgress.Full;
+    internal string ApiName { get; set; }
+    internal IEnumerable<Component> Inputs { get; set; }
+    internal IEnumerable<Component> Outputs { get; set; }
+    internal IEnumerable<FnTarget> Targets { get; set; }
+
+    internal Dictionary<string, object> GetConfig()
     {
-        internal bool Preprocess { get;  set; }
-        internal bool ShowApi { get;  set; }
-        internal bool ScrollToOutput { get;  set; }
-        internal bool? Queue { get;  set; }
-        internal bool TriggerOnlyOnSuccess { get;  set; }
-        internal int? TriggerAfter { get;  set; }
-        internal bool? CollectsEventData { get;  set; }
-        internal IEnumerable<int> Cancels { get;  set; }
-        internal decimal? Every { get;  set; }
-        internal bool TracksProgress { get;  set; }
-        internal string ConcurrencyId { get;  set; }
-        internal ConcurrencyLimit? ConcurrencyLimit { get;  set; }
-        internal bool Batch { get;  set; }
-        internal bool InputsAsDict { get;  set; }
-        internal bool Postprocess { get;  set; }
-        internal Func<Input,Task<Output>>? Fn { get;  set; }
-        internal Func<Input,IAsyncEnumerable<Output>>? StreamingFn { get; set; }
-        internal string? Js { get;  set; }
-        internal bool TypesContinuous { get;  set; }
-        internal bool TypesGenerator { get;  set; }
-        internal bool ZeroGpu { get; set; }
-        internal TriggerMode? TriggerMode { get; set; }
-        internal int MaxBatchSize { get; set; } = 4;
-        internal ShowProgress ShowProgress { get; set; } = ShowProgress.Full;
-        internal string ApiName { get; set; }
-        internal IEnumerable<Component> Inputs { get; set; }
-        internal IEnumerable<Component> Outputs { get; set; }
-        internal IEnumerable<FnTarget> Targets { get; set; }
-
-        internal Dictionary<string, object> GetConfig()
+        Dictionary<string, object> result = new()
         {
-            var result = new Dictionary<string, object>();
-            result["targets"] = GetTargetsConfig();
-            result["inputs"] = Inputs.Select(p => p.Id).ToArray();
-            result["outputs"] = Outputs.Select(p => p.Id).ToArray();
-            result["backend_fn"] = (this.Fn!=null|| this.StreamingFn!=null);
-            result["js"] = this.Js;
-            result["queue"] = this.Queue;
-            result["apiName"] = ApiName;
-            result["scrollToOutput"] = this.ScrollToOutput;
-            result["showProgress"] = ShowProgress.ToString().ToLowerInvariant();
-            result["every"] = this.Every;
-            result["batch"] = this.Batch;
-            result["maxBatchSize"] = MaxBatchSize;
-            result["cancels"] = this.Cancels;
-            result["types"] = new Dictionary<string, object> {
-                {"continuous",this.TypesContinuous },
-                {"generator",this.TypesGenerator }
-            };
-            result["collects_event_data"] = this.CollectsEventData;
-            result["trigger_after"] = this.TriggerAfter;
-            result["trigger_only_on_success"] = this.TriggerOnlyOnSuccess;
-            result["triggerMode"] = TriggerMode.ToString().ToLowerInvariant();
-            result["show_api"] = this.ShowApi;
-            result["zerogpu"] = this.ZeroGpu;
+            ["targets"] = GetTargetsConfig(),
+            ["inputs"] = Inputs.Select(p => p.Id).ToArray(),
+            ["outputs"] = Outputs.Select(p => p.Id).ToArray(),
+            ["backend_fn"] = (this.Fn != null || this.StreamingFn != null),
+            ["js"] = this.Js,
+            ["queue"] = this.Queue,
+            ["apiName"] = ApiName,
+            ["scrollToOutput"] = this.ScrollToOutput,
+            ["showProgress"] = ShowProgress.ToString().ToLowerInvariant(),
+            ["every"] = this.Every,
+            ["batch"] = this.Batch,
+            ["maxBatchSize"] = MaxBatchSize,
+            ["cancels"] = this.Cancels,
+            ["types"] = new Dictionary<string, object> {
+            {"continuous",this.TypesContinuous },
+            {"generator",this.TypesGenerator }
+        },
+            ["collects_event_data"] = this.CollectsEventData,
+            ["trigger_after"] = this.TriggerAfter,
+            ["trigger_only_on_success"] = this.TriggerOnlyOnSuccess,
+            ["triggerMode"] = TriggerMode.ToString().ToLowerInvariant(),
+            ["show_api"] = this.ShowApi,
+            ["zerogpu"] = this.ZeroGpu
+        };
 
-            return result;
-        }
+        return result;
+    }
 
-        private IEnumerable<object[]> GetTargetsConfig()
+    private IEnumerable<object[]> GetTargetsConfig()
+    {
+        List<object[]> result = [];  
+        foreach ((int? Id, string EventName) target in this.Targets)
         {
-            var result = new List<object[]>();  
-            foreach (var target in this.Targets)
-            {
-                result.Add(new object[] { target.Id,target.EventName});
-            }
-            return result;
+            result.Add([target.Id,target.EventName]);
         }
+        return result;
     }
 }

--- a/Gradio.Net/Components/Button.cs
+++ b/Gradio.Net/Components/Button.cs
@@ -1,24 +1,20 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Button : Component, IHaveClickEvent
 {
-    public class Button : Component, IHaveClickEvent
+    internal Button() { }
+
+    internal string Icon { get;  set; }
+    internal ButtonVariant Variant { get;   set; }
+    internal ButtonSize? Size { get;   set; }
+    internal string Link { get;   set; }
+
+
+    protected override Dictionary<string, object> GetApiInfo()
     {
-        internal Button() { }
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
 
-        internal string Icon { get;  set; }
-        internal ButtonVariant Variant { get;   set; }
-        internal ButtonSize? Size { get;   set; }
-        internal string Link { get;   set; }
-
-
-        protected override Dictionary<string, object> GetApiInfo()
-        {
-            return new Dictionary<string, object>() { { "type", "string" } };
-        }
-
-           }
-}
+       }

--- a/Gradio.Net/Components/Chatbot .cs
+++ b/Gradio.Net/Components/Chatbot .cs
@@ -1,145 +1,135 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Text.Json;
-using Gradio.Net.Models;
-using System.IO;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class Chatbot : Component
 {
-    public class Chatbot : Component
+    internal Chatbot() { }
+
+    internal int? Height { get;  set; }
+    internal IEnumerable<Dictionary<string, object>> LatexDelimiters { get;  set; }
+    internal bool ShowShareButton { get;  set; }
+    internal bool RenderMarkdown { get;  set; }
+    internal bool ShowCopyButton { get;  set; }
+    internal Tuple<string, string> AvatarImages { get;  set; }
+    internal bool SanitizeHtml { get;  set; }
+    internal bool BubbleFullWidth { get;  set; }
+    internal bool LineBreaks { get;  set; }
+    internal bool Likeable { get;  set; }
+    internal string Layout { get;  set; }
+    internal string Placeholder { get;  set; }
+
+    protected override Dictionary<string, object> GetApiInfo()
     {
-        internal Chatbot() { }
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
 
-        internal int? Height { get;  set; }
-        internal IEnumerable<Dictionary<string, object>> LatexDelimiters { get;  set; }
-        internal bool ShowShareButton { get;  set; }
-        internal bool RenderMarkdown { get;  set; }
-        internal bool ShowCopyButton { get;  set; }
-        internal Tuple<string, string> AvatarImages { get;  set; }
-        internal bool SanitizeHtml { get;  set; }
-        internal bool BubbleFullWidth { get;  set; }
-        internal bool LineBreaks { get;  set; }
-        internal bool Likeable { get;  set; }
-        internal string Layout { get;  set; }
-        internal string Placeholder { get;  set; }
-
-        protected override Dictionary<string, object> GetApiInfo()
+    private ChatMessage PreprocessChatMessages(string chatMessage)
+    {
+        if (chatMessage == null)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
+            return null;
         }
-
-        private ChatMessage PreprocessChatMessages(string chatMessage)
+        else if (chatMessage.Contains("gradio.FileMessage"))
         {
-            if (chatMessage == null)
+            FileMessage fileMessage = JsonUtils.Deserialize<FileMessage>(chatMessage);
+            if (!string.IsNullOrEmpty(fileMessage.AltText))
             {
-                return null;
-            }
-            else if (chatMessage.Contains("gradio.FileMessage"))
-            {
-                var fileMessage = JsonUtils.Deserialize<FileMessage>(chatMessage);
-                if (!string.IsNullOrEmpty(fileMessage.AltText))
-                {
-                    return new ChatMessage { FilePath = fileMessage.File.Path, AltText = fileMessage.AltText };
-                }
-                else
-                {
-                    return new ChatMessage { FilePath = fileMessage.File.Path };
-                }
-            }
-            
-
-            return new ChatMessage { TextMessage = chatMessage };            
-        }
-
-        internal override object PreProcess(object data)
-        {
-            List<ChatbotMessagePair> processedMessages = new List<ChatbotMessagePair>();
-            if (data == null)
-            {
-                return processedMessages;
-            }
-            var str = data.ToString();
-
-            var listMessagePair=  JsonUtils.Deserialize<List<string[]>>(str);
-
-            
-            foreach  (var messagePair in listMessagePair)
-            {
-                if (messagePair.Length != 2)
-                {
-                    throw new InvalidDataException(
-                        $"Expected a list of lists of length 2 or list of tuples of length 2. Received: {messagePair}"
-                    );
-                }
-                processedMessages.Add(new ChatbotMessagePair ( PreprocessChatMessages(messagePair[0]) , PreprocessChatMessages(messagePair[1]))) ;
-            }
-            return processedMessages;
-        }
-
-        private object PostprocessChatMessages(ChatMessage chatMessage)
-        {
-            if (chatMessage == null)
-            {
-                return null;
-            }
-            else if (!string.IsNullOrEmpty( chatMessage.FilePath))
-            {
-                var filePath = chatMessage.FilePath;
-
-                var mimeType = ClientUtils.GetMimeType(filePath);
-                return new FileMessage()
-                {
-                    File = new FileData() { Path = filePath, MimeType = mimeType },
-                    AltText = chatMessage.AltText,
-                };
-            }
-            else if(!string.IsNullOrEmpty(chatMessage.TextMessage))
-            {
-                return chatMessage.TextMessage;
+                return new ChatMessage { FilePath = fileMessage.File.Path, AltText = fileMessage.AltText };
             }
             else
             {
-                throw new ArgumentException($"Invalid message for Chatbot component: {chatMessage}");
+                return new ChatMessage { FilePath = fileMessage.File.Path };
             }
         }
+        
 
-        internal override object PostProcess(string rootUrl, object data)
+        return new ChatMessage { TextMessage = chatMessage };            
+    }
+
+    internal override object PreProcess(object data)
+    {
+        List<ChatbotMessagePair> processedMessages = [];
+        if (data == null)
         {
-            if (data == null) {
-                return new List<object[]>() ;
-            }
+            return processedMessages;
+        }
+        string? str = data.ToString();
 
-            var value = data as IList<ChatbotMessagePair>;
+        List<string[]> listMessagePair =  JsonUtils.Deserialize<List<string[]>>(str);
 
-            var processedMessages =  new List<object[]>();
-            foreach (var messagePair in value)
+        
+        foreach  (string[] messagePair in listMessagePair)
+        {
+            if (messagePair.Length != 2)
             {
-                processedMessages.Add(
-                    [
-                        PostprocessChatMessages(messagePair.HumanMessage),
-                        PostprocessChatMessages(messagePair.AiMessage),
-                    ]
+                throw new InvalidDataException(
+                    $"Expected a list of lists of length 2 or list of tuples of length 2. Received: {messagePair}"
                 );
-             }
-            return processedMessages ;
+            }
+            processedMessages.Add(new ChatbotMessagePair ( PreprocessChatMessages(messagePair[0]) , PreprocessChatMessages(messagePair[1]))) ;
         }
+        return processedMessages;
+    }
 
-        public static IList<ChatbotMessagePair> Payload(object obj)
+    private object PostprocessChatMessages(ChatMessage chatMessage)
+    {
+        if (chatMessage == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is IList<ChatbotMessagePair> list)
-            {
-                return list;
-            }
-
-            throw new ArgumentException($"Payload Type expect IList<ChatbotMessagePair> actual {obj.GetType()}");
+            return null;
         }
+        else if (!string.IsNullOrEmpty( chatMessage.FilePath))
+        {
+            string filePath = chatMessage.FilePath;
+
+            string mimeType = ClientUtils.GetMimeType(filePath);
+            return new FileMessage()
+            {
+                File = new FileData() { Path = filePath, MimeType = mimeType },
+                AltText = chatMessage.AltText,
+            };
+        }
+        else if(!string.IsNullOrEmpty(chatMessage.TextMessage))
+        {
+            return chatMessage.TextMessage;
+        }
+        else
+        {
+            throw new ArgumentException($"Invalid message for Chatbot component: {chatMessage}");
+        }
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null) {
+            return new List<object[]>() ;
+        }
+
+        IList<ChatbotMessagePair>? value = data as IList<ChatbotMessagePair>;
+
+        List<object[]> processedMessages =  [];
+        foreach (ChatbotMessagePair messagePair in value)
+        {
+            processedMessages.Add(
+                [
+                    PostprocessChatMessages(messagePair.HumanMessage),
+                    PostprocessChatMessages(messagePair.AiMessage),
+                ]
+            );
+         }
+        return processedMessages ;
+    }
+
+    public static IList<ChatbotMessagePair> Payload(object obj)
+    {
+        if (obj == null)
+        {
+            return null;
+        }
+
+        if (obj is IList<ChatbotMessagePair> list)
+        {
+            return list;
+        }
+
+        throw new ArgumentException($"Payload Type expect IList<ChatbotMessagePair> actual {obj.GetType()}");
     }
 }

--- a/Gradio.Net/Components/Component.cs
+++ b/Gradio.Net/Components/Component.cs
@@ -1,46 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
+﻿using System.Runtime.Serialization;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public abstract class Component : Block
 {
-    public abstract class Component : Block
+    internal Component()
     {
-        internal Component()
-        {
 
-        }
-        
-        internal bool Rtl { get; set; }
-        internal string Info { get; set; }
-        internal bool Container { get; set; } = true;
-        internal int? Scale { get; set; }
-        internal int? MinWidth { get; set; }
-        
-        [IgnoreDataMember]
-        internal Action LoadFn { get; set; }
-
-
-        internal object Value { get; set; }
-        internal string Label { get; set; }
-        internal decimal? Every { get; set; }
-        internal bool? ShowLabel { get; set; }
-        
+    }
     
-        protected virtual Dictionary<string, object> GetApiInfo() { 
-        return new Dictionary<string, object>();
-        }
+    internal bool Rtl { get; set; }
+    internal string Info { get; set; }
+    internal bool Container { get; set; } = true;
+    internal int? Scale { get; set; }
+    internal int? MinWidth { get; set; }
+    
+    [IgnoreDataMember]
+    internal Action LoadFn { get; set; }
 
-        
 
-        protected override Dictionary<string, object> GetProps()
-        {
-            var result= base.GetProps();
+    internal object Value { get; set; }
+    internal string Label { get; set; }
+    internal decimal? Every { get; set; }
+    internal bool? ShowLabel { get; set; }
+    
 
-           
+    protected virtual Dictionary<string, object> GetApiInfo() { 
+    return [];
+    }
 
-            return result;
-        }
+    
+
+    protected override Dictionary<string, object> GetProps()
+    {
+        Dictionary<string, object> result = base.GetProps();
+
+       
+
+        return result;
     }
 }

--- a/Gradio.Net/Components/HTML.cs
+++ b/Gradio.Net/Components/HTML.cs
@@ -1,42 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public class HTML:Component
 {
-    public class HTML:Component
+
+    internal HTML()
+    { 
+    }
+      
+
+    protected override Dictionary<string, object> GetApiInfo()
     {
-
-        internal HTML()
-        { 
-        }
-          
-
-        protected override Dictionary<string, object> GetApiInfo()
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+    internal override object PreProcess(object data)
+    {
+        string result = null;
+        if (data == null)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
-        }
-        internal override object PreProcess(object data)
-        {
-            string result = null;
-            if (data == null)
-            {
-                return result;
-            }
-
-            result = data.ToString();
             return result;
         }
 
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            if (data == null)
-            {
-                return null;
-            }
+        result = data.ToString();
+        return result;
+    }
 
-            return data.ToString();
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return null;
         }
+
+        return data.ToString();
     }
 }

--- a/Gradio.Net/Components/IStreamingInput.cs
+++ b/Gradio.Net/Components/IStreamingInput.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal interface IStreamingInput
 {
-    internal interface IStreamingInput
-    {
-        void CheckStreamable();
-    }
+    void CheckStreamable();
 }

--- a/Gradio.Net/Components/Image.cs
+++ b/Gradio.Net/Components/Image.cs
@@ -1,67 +1,59 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Text.Json;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Image : Component, IStreamingInput
 {
-    public class Image : Component, IStreamingInput
+    internal Image() { }
+    internal ImageFormat Format { get;  set; }
+    internal bool MirrorWebcam { get;  set; }
+    internal ImageType Type { get;  set; }
+    internal int? Height { get;  set; }
+    internal int? Width { get;  set; }
+    internal ImageMode ImageMode { get;  set; }
+    internal IEnumerable<ImageSource> Sources { get;  set; }
+    internal bool Streaming { get;  set; }
+    internal bool ShowDownloadButton { get;  set; }
+    internal bool? ShowShareButton { get;  set; }
+
+    public void CheckStreamable()
     {
-        internal Image() { }
-        internal ImageFormat Format { get;  set; }
-        internal bool MirrorWebcam { get;  set; }
-        internal ImageType Type { get;  set; }
-        internal int? Height { get;  set; }
-        internal int? Width { get;  set; }
-        internal ImageMode ImageMode { get;  set; }
-        internal IEnumerable<ImageSource> Sources { get;  set; }
-        internal bool Streaming { get;  set; }
-        internal bool ShowDownloadButton { get;  set; }
-        internal bool? ShowShareButton { get;  set; }
+        //todo
+    }
 
-        public void CheckStreamable()
+    internal override object PreProcess(object data)
+    {
+        string? str = data.ToString();
+
+        FileData fileData = JsonUtils.Deserialize<FileData>(str);
+        return fileData.Path;
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        string? str = data.ToString();
+
+        Context.DownloadableFiles.TryAdd(str, str);
+        if (ClientUtils.IsUrl(str))
         {
-            //todo
+            return new FileData { Path = null, Url = str };
+        }
+        
+        return new FileData { Path = str, Url = $"{rootUrl}/file={str}" };
+    }
+
+    public static string Payload(object obj)
+    {
+        if (obj == null)
+        {
+            return null;
         }
 
-        internal override object PreProcess(object data)
+        if (obj is string str)
         {
-            var str = data.ToString();
-
-            var fileData = JsonUtils.Deserialize<FileData>(str);
-            return fileData.Path;
+            return str;
         }
 
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            var str = data.ToString();
-
-            Context.DownloadableFiles.TryAdd(str, str);
-            if (ClientUtils.IsUrl(str))
-            {
-                return new FileData { Path = null, Url = str };
-            }
-            
-            return new FileData { Path = str, Url = $"{rootUrl}/file={str}" };
-        }
-
-        public static string Payload(object obj)
-        {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is string str)
-            {
-                return str;
-            }
-
-            throw new ArgumentException($"Payload Type expect string actual {obj.GetType()}");
-        }
+        throw new ArgumentException($"Payload Type expect string actual {obj.GetType()}");
     }
 }

--- a/Gradio.Net/Components/Label.cs
+++ b/Gradio.Net/Components/Label.cs
@@ -1,36 +1,30 @@
 ﻿using Gradio.Net.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Label : Component
 {
-    public class Label : Component
+    internal Label() { }
+
+    internal int? NumTopClasses { get;  set; }
+    internal string Color { get;  set; }
+    internal override object PreProcess(object data)
     {
-        internal Label() { }
-
-        internal int? NumTopClasses { get;  set; }
-        internal string Color { get;  set; }
-        internal override object PreProcess(object data)
+        string result = null;
+        if (data == null)
         {
-            string result = null;
-            if (data == null)
-            {
-                return result;
-            }
-
-            result = data.ToString();
             return result;
         }
-        internal override object PostProcess(string rootUrl, object data)
+
+        result = data.ToString();
+        return result;
+    }
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
         {
-            if (data == null)
-            {
-                return new LabelData();
-            }
-            return new LabelData { Label= data.ToString() };
+            return new LabelData();
         }
+        return new LabelData { Label= data.ToString() };
     }
 }

--- a/Gradio.Net/Components/Markdown.cs
+++ b/Gradio.Net/Components/Markdown.cs
@@ -1,66 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public class Markdown:Component
 {
-    public class Markdown:Component
+    private IEnumerable<Dictionary<string, object>> _latexDelimiters;
+
+    internal Markdown()
     {
-        private IEnumerable<Dictionary<string, object>> _latexDelimiters;
+        this._latexDelimiters = new List<Dictionary<string, object>>
+                { 
+                    new() {
+                        { "left", "$$"},{"right", "$$" },{ "display", true}
+                    }
+                };
+    }
 
-        internal Markdown()
+    internal IEnumerable<Dictionary<string, object>> LatexDelimiters 
+    { 
+        get 
         {
-            this._latexDelimiters = new List<Dictionary<string, object>>
-                    { 
-                        new Dictionary<string, object>
-                        {
-                            { "left", "$$"},{"right", "$$" },{ "display", true}
-                        }
-                    };
+            return _latexDelimiters;
         }
-
-        internal IEnumerable<Dictionary<string, object>> LatexDelimiters 
-        { 
-            get 
+        set {
+            if (value != null)
             {
-                return _latexDelimiters;
-            }
-            set {
-                if (value != null)
-                {
-                    _latexDelimiters = value;
-                }
+                _latexDelimiters = value;
             }
         }
-        internal bool SanitizeHtml { get;  set; }
-        internal bool LineBreaks { get;  set; }
-        internal bool HeaderLinks { get; set; }
+    }
+    internal bool SanitizeHtml { get;  set; }
+    internal bool LineBreaks { get;  set; }
+    internal bool HeaderLinks { get; set; }
 
-        protected override Dictionary<string, object> GetApiInfo()
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+    internal override object PreProcess(object data)
+    {
+        string result = null;
+        if (data == null)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
-        }
-        internal override object PreProcess(object data)
-        {
-            string result = null;
-            if (data == null)
-            {
-                return result;
-            }
-
-            result = data.ToString();
             return result;
         }
 
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            if (data == null)
-            {
-                return null;
-            }
+        result = data.ToString();
+        return result;
+    }
 
-            return data.ToString();
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return null;
         }
+
+        return data.ToString();
     }
 }

--- a/Gradio.Net/Context.cs
+++ b/Gradio.Net/Context.cs
@@ -1,96 +1,91 @@
-﻿
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Concurrent;
 using System.Threading.Channels;
 
 
-namespace Gradio.Net
-{
-    internal static class Context
-    {
-        internal static ConcurrentDictionary<string,string> DownloadableFiles { get; private set; } = new ConcurrentDictionary<string,string>();
-        internal static ConcurrentDictionary<string, EventResult> EventResults { get; private set; } =  new ConcurrentDictionary<string, EventResult>();
-        internal static Channel<Event> EventChannel { get; private set; } = Channel.CreateUnbounded<Event>();
-        internal static Blocks RootBlock { get; private set; } = null;
+namespace Gradio.Net;
 
-        private static Blocks _currentBlocks = null;
-        internal static void SetCurrentBlocks(Blocks blocks)
-        {
-            if (RootBlock == null && blocks != null)
-            { 
-                RootBlock = blocks;
+internal static class Context
+{
+    internal static ConcurrentDictionary<string,string> DownloadableFiles { get; private set; } = new ConcurrentDictionary<string,string>();
+    internal static ConcurrentDictionary<string, EventResult> EventResults { get; private set; } =  new ConcurrentDictionary<string, EventResult>();
+    internal static Channel<Event> EventChannel { get; private set; } = Channel.CreateUnbounded<Event>();
+    internal static Blocks RootBlock { get; private set; } = null;
+
+    private static Blocks _currentBlocks = null;
+    internal static void SetCurrentBlocks(Blocks blocks)
+    {
+        if (RootBlock == null && blocks != null)
+        { 
+            RootBlock = blocks;
+        }
+        if (_currentBlocks == null)
+        { 
+            if (blocks != null)
+            {
+                _currentBlocks = blocks;
             }
-            if (_currentBlocks == null)
-            { 
-                if (blocks != null)
-                {
-                    _currentBlocks = blocks;
-                }
+        }
+        else
+        {
+            if (blocks != null)
+            {
+                _currentBlocks.Add(blocks);
+                _currentBlocks = blocks;
             }
             else
             {
-                if (blocks != null)
+                Form formParent = null;
+                Tabs tabsParent = null;
+                List<Block> children = _currentBlocks.ToList();
+                for (int i = 0; i < children.Count; i++)                   
                 {
-                    _currentBlocks.Add(blocks);
-                    _currentBlocks = blocks;
-                }
-                else
-                {
-                    Form formParent = null;
-                    Tabs tabsParent = null;
-                    var children = _currentBlocks.ToList();
-                    for (var i = 0; i < children.Count; i++)                   
-                    { 
-                        var child = children[i];
-                        if (child is Tab tab)
-                        {                            
-                            if (tabsParent == null)
-                            {
-                                tabsParent = new Tabs();
-                                _currentBlocks.Insert(i, tabsParent);
-                                tabsParent.ParentBlocks = _currentBlocks;
-                                tabsParent.Render = false;
-
-                            }
-
-                            tabsParent.Add(tab);
-                            _currentBlocks.Remove(child);
-                           
-                        }
-                        else if (child is FormComponent formComponent)
+                    Block child = children[i];
+                    if (child is Tab tab)
+                    {                            
+                        if (tabsParent == null)
                         {
-                            if (formComponent.Container)
+                            tabsParent = [];
+                            _currentBlocks.Insert(i, tabsParent);
+                            tabsParent.ParentBlocks = _currentBlocks;
+                            tabsParent.Render = false;
+
+                        }
+
+                        tabsParent.Add(tab);
+                        _currentBlocks.Remove(child);
+                       
+                    }
+                    else if (child is FormComponent formComponent)
+                    {
+                        if (formComponent.Container)
+                        {
+                            if (formParent == null)
                             {
-                                if (formParent == null)
-                                {
-                                    formParent = new Form();
-                                    _currentBlocks.Insert(i,formParent);
-                                    formParent.ParentBlocks = _currentBlocks;
-                                    formParent.Render = false;
-                                    
-                                }
+                                formParent = [];
+                                _currentBlocks.Insert(i,formParent);
+                                formParent.ParentBlocks = _currentBlocks;
+                                formParent.Render = false;
                                 
-                                formParent.Add(formComponent);
-                                _currentBlocks.Remove(child);
                             }
+                            
+                            formParent.Add(formComponent);
+                            _currentBlocks.Remove(child);
                         }
                     }
-                    _currentBlocks = _currentBlocks.ParentBlocks;
                 }
+                _currentBlocks = _currentBlocks.ParentBlocks;
             }
         }
+    }
 
-        internal static void AddToCurrentBlocks(Block block)
-        {
-            _currentBlocks.Add(block);
-        }
+    internal static void AddToCurrentBlocks(Block block)
+    {
+        _currentBlocks.Add(block);
+    }
 
-        private static int _id = 0;
-        internal static int NextId()
-        {
-            return _id++;
-        }
+    private static int _id = 0;
+    internal static int NextId()
+    {
+        return _id++;
     }
 }

--- a/Gradio.Net/Enums/ButtonSize.cs
+++ b/Gradio.Net/Enums/ButtonSize.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ButtonSize
 {
-    public enum ButtonSize
-    {
-        Sm=0,
-        Lg=1,
-    }
+    Sm=0,
+    Lg=1,
 }

--- a/Gradio.Net/Enums/ButtonVariant.cs
+++ b/Gradio.Net/Enums/ButtonVariant.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ButtonVariant
 {
-    public enum ButtonVariant
-    {
-        Primary=0, 
-        Secondary=1,
-        Stop=2,
-    }
+    Primary=0, 
+    Secondary=1,
+    Stop=2,
 }

--- a/Gradio.Net/Enums/CheckboxGroupType.cs
+++ b/Gradio.Net/Enums/CheckboxGroupType.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum CheckboxGroupType
 {
-    public enum CheckboxGroupType
-    {
-        Value = 0,
-        Index
-    }
+    Value = 0,
+    Index
 }

--- a/Gradio.Net/Enums/ColumnVariant.cs
+++ b/Gradio.Net/Enums/ColumnVariant.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ColumnVariant
 {
-    public enum ColumnVariant
-    {
-        Default = 0,
-        Panel = 1,
-        Compact = 2,
-    }
+    Default = 0,
+    Panel = 1,
+    Compact = 2,
 }

--- a/Gradio.Net/Enums/ConcurrencyLimit.cs
+++ b/Gradio.Net/Enums/ConcurrencyLimit.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ConcurrencyLimit
 {
-    public enum ConcurrencyLimit
-    {
-        Default=0,
-    }
+    Default=0,
 }

--- a/Gradio.Net/Enums/DropdownType.cs
+++ b/Gradio.Net/Enums/DropdownType.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum DropdownType
 {
-    public enum DropdownType
-    {
-        Value = 0,
-        Index
-    }
+    Value = 0,
+    Index
 }

--- a/Gradio.Net/Enums/ImageFormat.cs
+++ b/Gradio.Net/Enums/ImageFormat.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ImageFormat
 {
-    public enum ImageFormat
-    {
-        Webp=0
-    }
+    Webp=0
 }

--- a/Gradio.Net/Enums/ImageMode.cs
+++ b/Gradio.Net/Enums/ImageMode.cs
@@ -1,22 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ImageMode
 {
-    public enum ImageMode
-    {
-        L=0, 
-        P, 
-        RGB, 
-        RGBA,
-        CMYK, 
-        YCbCr,
-        LAB, 
-        HSV, 
-        I, 
-        F
-    }
+    L=0, 
+    P, 
+    RGB, 
+    RGBA,
+    CMYK, 
+    YCbCr,
+    LAB, 
+    HSV, 
+    I, 
+    F
 }

--- a/Gradio.Net/Enums/ImageSource.cs
+++ b/Gradio.Net/Enums/ImageSource.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ImageSource
 {
-    public enum ImageSource
-    {
-        Upload=0,
-        Webcam, 
-        Clipboard
-    }
+    Upload=0,
+    Webcam, 
+    Clipboard
 }

--- a/Gradio.Net/Enums/ImageType.cs
+++ b/Gradio.Net/Enums/ImageType.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ImageType
 {
-    public enum ImageType
-    {
-        Filepath=0,
-    }
+    Filepath=0,
 }

--- a/Gradio.Net/Enums/RadioType.cs
+++ b/Gradio.Net/Enums/RadioType.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum RadioType
 {
-    public enum RadioType
-    {
-        Value = 0,
-        Index
-    }
+    Value = 0,
+    Index
 }

--- a/Gradio.Net/Enums/RowVariant.cs
+++ b/Gradio.Net/Enums/RowVariant.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum RowVariant
 {
-    public enum RowVariant
-    {
-        Default = 0,
-        Panel = 1,
-        Compact = 2,
-    }
+    Default = 0,
+    Panel = 1,
+    Compact = 2,
 }

--- a/Gradio.Net/Enums/SSEMessageType.cs
+++ b/Gradio.Net/Enums/SSEMessageType.cs
@@ -1,26 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum SSEMessageType
 {
-    public enum SSEMessageType
-    {
-        SendHash =0,
-        QueueFull,
-        Estimation,
-        SendData,
-        ProcessStarts,
-        ProcessGenerating,
-        ProcessCompleted,
-        Log,
-        Progress,
-        Heartbeat,
-        ServerStopped,
-        UnexpectedError,
-        CloseStream
-    }
+    SendHash =0,
+    QueueFull,
+    Estimation,
+    SendData,
+    ProcessStarts,
+    ProcessGenerating,
+    ProcessCompleted,
+    Log,
+    Progress,
+    Heartbeat,
+    ServerStopped,
+    UnexpectedError,
+    CloseStream
 }

--- a/Gradio.Net/Enums/ShowProgress.cs
+++ b/Gradio.Net/Enums/ShowProgress.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum ShowProgress
 {
-    public enum ShowProgress
-    {
-        Full=0, 
-        Minimal=1, 
-        Hidden=2
-    }
+    Full=0, 
+    Minimal=1, 
+    Hidden=2
 }

--- a/Gradio.Net/Enums/TextAlign.cs
+++ b/Gradio.Net/Enums/TextAlign.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum TextboxTextAlign
 {
-    public enum TextboxTextAlign
-    {
-        Left=0,
-        Right=1,
-    }
+    Left=0,
+    Right=1,
 }

--- a/Gradio.Net/Enums/TextboxType.cs
+++ b/Gradio.Net/Enums/TextboxType.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum TextboxType
 {
-    public enum TextboxType
-    {
-        Text = 0,
-        Password = 1,
-        Email = 2
-    }
+    Text = 0,
+    Password = 1,
+    Email = 2
 }

--- a/Gradio.Net/Enums/TriggerMode.cs
+++ b/Gradio.Net/Enums/TriggerMode.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Enums;
 
-namespace Gradio.Net.Enums
+public enum TriggerMode
 {
-    public enum TriggerMode
-    {
-        Once=0, 
-        Multiple=1, 
-        AlwaysLast=2,
-    }
+    Once=0, 
+    Multiple=1, 
+    AlwaysLast=2,
 }

--- a/Gradio.Net/EventWorker.cs
+++ b/Gradio.Net/EventWorker.cs
@@ -1,51 +1,43 @@
 ﻿using Microsoft.Extensions.Hosting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Text.Json;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class EventWorker : BackgroundService
 {
-    internal class EventWorker : BackgroundService
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            Event eventIn = await Context.EventChannel.Reader.ReadAsync(stoppingToken);
+            if (eventIn == null)
             {
-                var eventIn = await Context.EventChannel.Reader.ReadAsync(stoppingToken);
-                if (eventIn == null)
-                {
-                    await Task.Delay(500, stoppingToken);
-                    continue;
-                }
+                await Task.Delay(500, stoppingToken);
+                continue;
+            }
 
-                if (eventIn.FnIndex >= 0 && eventIn.FnIndex < Context.RootBlock.Fns.Count)
-                {
-                    var blockFunction = Context.RootBlock.Fns[eventIn.FnIndex];
-                    var fn = blockFunction.Fn;
-                    var streamingFn = blockFunction.StreamingFn;
-                    var data = eventIn.Data.Data;
+            if (eventIn.FnIndex >= 0 && eventIn.FnIndex < Context.RootBlock.Fns.Count)
+            {
+                BlockFunction blockFunction = Context.RootBlock.Fns[eventIn.FnIndex];
+                Func<Input, Task<Output>>? fn = blockFunction.Fn;
+                Func<Input, IAsyncEnumerable<Output>>? streamingFn = blockFunction.StreamingFn;
+                object[] data = eventIn.Data.Data;
 
-                    _ = Task.Factory.StartNew(()=>
+                _ = Task.Factory.StartNew(()=>
+                {
+                    try
                     {
-                        try
-                        {
-                            var input = gr.Input(blockFunction, data);
-                            Context.EventResults.TryAdd(eventIn.SessionHash, new EventResult { Event = eventIn, BlockFunction = blockFunction, Input = input, OutputTask = fn?.Invoke(input), StreamingOutputTask = streamingFn?.Invoke(input) });
-                        }
-                        catch (Exception ex)
-                        {
-                            Context.EventResults.TryAdd(eventIn.SessionHash, new EventResult { Event = eventIn, BlockFunction = blockFunction, OutputTask = Task.FromResult<Output>(new ErrorOutput(ex)) }); ;
-                        }
-                    }, default, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default); 
-                }
-                else
-                {
-                    Context.EventResults.TryAdd(eventIn.SessionHash, null);
-                }
+                        Input input = gr.Input(blockFunction, data);
+                        Context.EventResults.TryAdd(eventIn.SessionHash, new EventResult { Event = eventIn, BlockFunction = blockFunction, Input = input, OutputTask = fn?.Invoke(input), StreamingOutputTask = streamingFn?.Invoke(input) });
+                    }
+                    catch (Exception ex)
+                    {
+                        Context.EventResults.TryAdd(eventIn.SessionHash, new EventResult { Event = eventIn, BlockFunction = blockFunction, OutputTask = Task.FromResult<Output>(new ErrorOutput(ex)) }); ;
+                    }
+                }, default, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default); 
+            }
+            else
+            {
+                Context.EventResults.TryAdd(eventIn.SessionHash, null);
             }
         }
     }

--- a/Gradio.Net/Events/Dependency.cs
+++ b/Gradio.Net/Events/Dependency.cs
@@ -1,24 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal class Dependency
 {
-    internal class Dependency
+    public Dependency(Block block, Dictionary<string, object> config, int dep_index, Func<Input,Task<Output>> fn)
     {
-        public Dependency(Block block, Dictionary<string, object> config, int dep_index, Func<Input,Task<Output>> fn)
-        {
-            Block = block;
-            Config = config;
-            DepIndex = dep_index;
-            Fn = fn;
-        }
-
-        internal Block Block { get; }
-        internal Dictionary<string, object> Config { get; }
-        internal int DepIndex { get; }
-        internal Func<Input,Task<Output>> Fn { get; }
+        Block = block;
+        Config = config;
+        DepIndex = dep_index;
+        Fn = fn;
     }
+
+    internal Block Block { get; }
+    internal Dictionary<string, object> Config { get; }
+    internal int DepIndex { get; }
+    internal Func<Input,Task<Output>> Fn { get; }
 }

--- a/Gradio.Net/Events/EventListener.cs
+++ b/Gradio.Net/Events/EventListener.cs
@@ -1,101 +1,91 @@
 ﻿using Gradio.Net.Enums;
-using Gradio.Net.jinja2;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics.Arm;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class EventListener
 {
-    internal class EventListener
-    {
-        internal EventListener(string event_name,
-        bool has_trigger=true,
-        Func<Dictionary<string,object>> configData = null,
-        ShowProgress showProgress= ShowProgress.Full,
-        Func<Block, Task> callback=null,
-        int ?trigger_after=null,
-        bool trigger_only_on_success=false,
-        string doc= "") {
-            this.HasTrigger = has_trigger;
-            this.ConfigData = configData;
-            this.EventName = event_name;
-            this.ShowProgress = showProgress;
-            this.TriggerAfter = trigger_after;
-            this.TriggerOnlyOnSuccess = trigger_only_on_success;
-            this.Callback = callback;
-            this.Doc = doc;
-        }
-
-        public bool HasTrigger { get; }
-        public Func<Dictionary<string, object>> ConfigData { get; }
-        public string EventName { get; }
-        public ShowProgress ShowProgress { get; }
-        public int? TriggerAfter { get; }
-        public bool TriggerOnlyOnSuccess { get; }
-        public Func<Block,Task> Callback { get; }
-        public string Doc { get; }
-
-
-        internal async Task<Dependency> EventTrigger(
-            Block block,
-            Func<Input,Task<Output>> fn = null,
-             Func<Input,IAsyncEnumerable<Output>> streamingFn = null,
-            IEnumerable<Component> inputs=null,
-            IEnumerable<Component> outputs=null,
-            string apiName=null,
-            bool scrollToOutput=false,
-            ShowProgress? showProgress=null,
-            bool? queue=null,
-            bool batch=false,
-            int maxBatchSize= 4,
-            bool preprocess = true,
-            bool postprocess=true,
-            Dictionary<string,object> cancels=null,
-            decimal? every=null,
-            TriggerMode? triggerMode=null,
-            string js=null,
-            ConcurrencyLimit concurrencyLimit= ConcurrencyLimit.Default,
-            string concurrencyId=null,
-            bool showApi=true
-        )
-        {
-            (BlockFunction dep, int dep_index) = Context.RootBlock.SetEventTrigger(
-                new[] { new EventListenerMethod(this.HasTrigger?block:null,this.EventName) },
-                fn,
-                streamingFn,
-                inputs,
-                outputs,
-                preprocess : preprocess,
-                postprocess : postprocess,
-                scrollToOutput : scrollToOutput,
-                showProgress : showProgress?? this.ShowProgress,
-                apiName : apiName,
-                js : js,
-                concurrencyLimit : concurrencyLimit,
-                concurrencyId : concurrencyId,
-                queue : queue,
-                batch : batch,
-                maxBatchSize : maxBatchSize,
-                every : every,
-                trigger_after : TriggerAfter,
-                trigger_only_on_success : TriggerOnlyOnSuccess,
-                triggerMode : triggerMode,
-                showApi : showApi
-            );
-            
-            if (Callback!=null)
-            {
-                await Callback(block);
-            }
-
-            return new Dependency(block, dep.GetConfig(), dep_index, fn);
-        }
+    internal EventListener(string event_name,
+    bool has_trigger=true,
+    Func<Dictionary<string,object>> configData = null,
+    ShowProgress showProgress= ShowProgress.Full,
+    Func<Block, Task> callback=null,
+    int ?trigger_after=null,
+    bool trigger_only_on_success=false,
+    string doc= "") {
+        this.HasTrigger = has_trigger;
+        this.ConfigData = configData;
+        this.EventName = event_name;
+        this.ShowProgress = showProgress;
+        this.TriggerAfter = trigger_after;
+        this.TriggerOnlyOnSuccess = trigger_only_on_success;
+        this.Callback = callback;
+        this.Doc = doc;
     }
 
-   
+    public bool HasTrigger { get; }
+    public Func<Dictionary<string, object>> ConfigData { get; }
+    public string EventName { get; }
+    public ShowProgress ShowProgress { get; }
+    public int? TriggerAfter { get; }
+    public bool TriggerOnlyOnSuccess { get; }
+    public Func<Block,Task> Callback { get; }
+    public string Doc { get; }
+
+
+    internal async Task<Dependency> EventTrigger(
+        Block block,
+        Func<Input,Task<Output>> fn = null,
+         Func<Input,IAsyncEnumerable<Output>> streamingFn = null,
+        IEnumerable<Component> inputs=null,
+        IEnumerable<Component> outputs=null,
+        string apiName=null,
+        bool scrollToOutput=false,
+        ShowProgress? showProgress=null,
+        bool? queue=null,
+        bool batch=false,
+        int maxBatchSize= 4,
+        bool preprocess = true,
+        bool postprocess=true,
+        Dictionary<string,object> cancels=null,
+        decimal? every=null,
+        TriggerMode? triggerMode=null,
+        string js=null,
+        ConcurrencyLimit concurrencyLimit= ConcurrencyLimit.Default,
+        string concurrencyId=null,
+        bool showApi=true
+    )
+    {
+        (BlockFunction dep, int dep_index) = Context.RootBlock.SetEventTrigger(
+            [new EventListenerMethod(this.HasTrigger?block:null,this.EventName)],
+            fn,
+            streamingFn,
+            inputs,
+            outputs,
+            preprocess : preprocess,
+            postprocess : postprocess,
+            scrollToOutput : scrollToOutput,
+            showProgress : showProgress?? this.ShowProgress,
+            apiName : apiName,
+            js : js,
+            concurrencyLimit : concurrencyLimit,
+            concurrencyId : concurrencyId,
+            queue : queue,
+            batch : batch,
+            maxBatchSize : maxBatchSize,
+            every : every,
+            trigger_after : TriggerAfter,
+            trigger_only_on_success : TriggerOnlyOnSuccess,
+            triggerMode : triggerMode,
+            showApi : showApi
+        );
+        
+        if (Callback!=null)
+        {
+            await Callback(block);
+        }
+
+        return new Dependency(block, dep.GetConfig(), dep_index, fn);
+    }
 }
+
+

--- a/Gradio.Net/Events/EventListenerMethod.cs
+++ b/Gradio.Net/Events/EventListenerMethod.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal class EventListenerMethod
 {
-    internal class EventListenerMethod
+    public EventListenerMethod(Block block, string eventName)
     {
-        public EventListenerMethod(Block block, string eventName)
-        {
-            Block = block;
-            EventName = eventName;
-        }
-
-        internal Block Block { get; set; }
-        internal string EventName {  get; set; }
+        Block = block;
+        EventName = eventName;
     }
+
+    internal Block Block { get; set; }
+    internal string EventName {  get; set; }
 }

--- a/Gradio.Net/Events/Events.cs
+++ b/Gradio.Net/Events/Events.cs
@@ -1,63 +1,56 @@
 ﻿using Gradio.Net.Enums;
-using Gradio.Net.jinja2;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public interface IHaveReleaseEvent
 {
-    public interface IHaveReleaseEvent
-    {
-    }
-    
-    public interface IHaveChangeEvent
-    {
-    }
-    public interface IHaveBlurEvent
-    {
-    }
-    public interface IHaveFocusEvent
-    {
-    }
-    public interface IHaveSubmitEvent
-    {
-    }
-    public interface IHaveSelectEvent
-    {
-    }
-    public interface IHaveInputEvent
-    {
-    }
-    public interface IHaveClickEvent
-    {
-    }
-    internal static class Events
-    {
-        internal static EventListener Click { get; } = new EventListener("click", doc: "Triggered when the {{ component }} is clicked.");
-        internal static EventListener Change { get; } = new EventListener("change", doc: "Triggered when the value of the {{ component }} changes either because of user input (e.g. a user types in a textbox) OR because of a function update (e.g. an image receives a value from the output of an event trigger). See `.input()` for a listener that is only triggered by user input.");
-        internal static EventListener Input { get; } = new EventListener("input", doc: "This listener is triggered when the user changes the value of the {{ component }}.");
-        internal static EventListener Submit { get; } = new EventListener("submit", doc: "This listener is triggered when the user presses the Enter key while the {{ component }} is focused.");
-        internal static EventListener Edit { get; } = new EventListener("edit", doc: "This listener is triggered when the user edits the {{ component }} (e.g. image) using the built-in editor.");
-        internal static EventListener Clear { get; } = new EventListener("clear", doc: "This listener is triggered when the user clears the {{ component }} using the X button for the component.");
-        internal static EventListener Play { get; } = new EventListener("play", doc: "This listener is triggered when the user plays the media in the {{ component }}.");
-        internal static EventListener Pause { get; } = new EventListener("pause", doc: "This listener is triggered when the media in the {{ component }} stops for any reason.");
-        internal static EventListener Stop { get; } = new EventListener("stop", doc: "This listener is triggered when the user reaches the end of the media playing in the {{ component }}.");
-        internal static EventListener End { get; } = new EventListener("end", doc: "This listener is triggered when the user reaches the end of the media playing in the {{ component }}.");
+}
 
-        internal static EventListener StartRecording { get; } = new EventListener("start_recording", doc: "This listener is triggered when the user starts recording with the {{ component }}.");
-        internal static EventListener PauseRecording { get; } = new EventListener("pause_recording", doc: "This listener is triggered when the user pauses recording with the {{ component }}.");
-        internal static EventListener StopRecording { get; } = new EventListener("stop_recording", doc: "This listener is triggered when the user stops recording with the {{ component }}.");
-        internal static EventListener Focus { get; } = new EventListener("focus", doc: "This listener is triggered when the {{ component }} is focused.");
-        internal static EventListener Blur { get; } = new EventListener("blur", doc: "This listener is triggered when the {{ component }} is unfocused/blurred.");
-        internal static EventListener Upload { get; } = new EventListener("upload", doc: "This listener is triggered when the user uploads a file into the {{ component }}.");
-        internal static EventListener Release { get; } = new EventListener("release", doc: "This listener is triggered when the user releases the mouse on this {{ component }}.");
-        internal static EventListener Select { get; } = new EventListener("select", callback: async (block)=>await block.SetSelectable(true), doc: "Event listener for when the user selects or deselects the {{ component }}. Uses event data gradio.SelectData to carry `value` referring to the label of the {{ component }}, and `selected` to refer to state of the {{ component }}. See EventData documentation on how to use this event data");
-        internal static EventListener Stream { get; } = new EventListener("stream", showProgress: ShowProgress.Hidden, configData: ()=>new Dictionary<string, object> {{ "streamable", false } } ,callback:  async (block) => block.Streaming =true, doc: "This listener is triggered when the user streams the {{ component }}.");
-        internal static EventListener Like { get; } = new EventListener("like", showProgress: ShowProgress.Hidden, configData: () => new Dictionary<string, object> { { "likeable", false } }, callback: async (block) => block.Likeable = true, doc: "This listener is triggered when the user likes/dislikes from within the {{ component }}. This event has EventData of type gradio.LikeData that carries information, accessible through LikeData.index and LikeData.value. See EventData documentation on how to use this event data.");
-        internal static EventListener Load { get; } = new EventListener("load", doc: "This listener is triggered when the {{ component }} initially loads in the browser.");
-        internal static EventListener KeyUp { get; } = new EventListener("key_up", doc: "This listener is triggered when the user presses a key while the {{ component }} is focused.");
-        internal static EventListener Apply { get; } = new EventListener("apply", doc: "This listener is triggered when the user applies changes to the {{ component }} through an integrated UI action.");
-    }
+public interface IHaveChangeEvent
+{
+}
+public interface IHaveBlurEvent
+{
+}
+public interface IHaveFocusEvent
+{
+}
+public interface IHaveSubmitEvent
+{
+}
+public interface IHaveSelectEvent
+{
+}
+public interface IHaveInputEvent
+{
+}
+public interface IHaveClickEvent
+{
+}
+internal static class Events
+{
+    internal static EventListener Click { get; } = new EventListener("click", doc: "Triggered when the {{ component }} is clicked.");
+    internal static EventListener Change { get; } = new EventListener("change", doc: "Triggered when the value of the {{ component }} changes either because of user input (e.g. a user types in a textbox) OR because of a function update (e.g. an image receives a value from the output of an event trigger). See `.input()` for a listener that is only triggered by user input.");
+    internal static EventListener Input { get; } = new EventListener("input", doc: "This listener is triggered when the user changes the value of the {{ component }}.");
+    internal static EventListener Submit { get; } = new EventListener("submit", doc: "This listener is triggered when the user presses the Enter key while the {{ component }} is focused.");
+    internal static EventListener Edit { get; } = new EventListener("edit", doc: "This listener is triggered when the user edits the {{ component }} (e.g. image) using the built-in editor.");
+    internal static EventListener Clear { get; } = new EventListener("clear", doc: "This listener is triggered when the user clears the {{ component }} using the X button for the component.");
+    internal static EventListener Play { get; } = new EventListener("play", doc: "This listener is triggered when the user plays the media in the {{ component }}.");
+    internal static EventListener Pause { get; } = new EventListener("pause", doc: "This listener is triggered when the media in the {{ component }} stops for any reason.");
+    internal static EventListener Stop { get; } = new EventListener("stop", doc: "This listener is triggered when the user reaches the end of the media playing in the {{ component }}.");
+    internal static EventListener End { get; } = new EventListener("end", doc: "This listener is triggered when the user reaches the end of the media playing in the {{ component }}.");
+
+    internal static EventListener StartRecording { get; } = new EventListener("start_recording", doc: "This listener is triggered when the user starts recording with the {{ component }}.");
+    internal static EventListener PauseRecording { get; } = new EventListener("pause_recording", doc: "This listener is triggered when the user pauses recording with the {{ component }}.");
+    internal static EventListener StopRecording { get; } = new EventListener("stop_recording", doc: "This listener is triggered when the user stops recording with the {{ component }}.");
+    internal static EventListener Focus { get; } = new EventListener("focus", doc: "This listener is triggered when the {{ component }} is focused.");
+    internal static EventListener Blur { get; } = new EventListener("blur", doc: "This listener is triggered when the {{ component }} is unfocused/blurred.");
+    internal static EventListener Upload { get; } = new EventListener("upload", doc: "This listener is triggered when the user uploads a file into the {{ component }}.");
+    internal static EventListener Release { get; } = new EventListener("release", doc: "This listener is triggered when the user releases the mouse on this {{ component }}.");
+    internal static EventListener Select { get; } = new EventListener("select", callback: async (block)=>await block.SetSelectable(true), doc: "Event listener for when the user selects or deselects the {{ component }}. Uses event data gradio.SelectData to carry `value` referring to the label of the {{ component }}, and `selected` to refer to state of the {{ component }}. See EventData documentation on how to use this event data");
+    internal static EventListener Stream { get; } = new EventListener("stream", showProgress: ShowProgress.Hidden, configData: ()=>new Dictionary<string, object> {{ "streamable", false } } ,callback:  async (block) => block.Streaming =true, doc: "This listener is triggered when the user streams the {{ component }}.");
+    internal static EventListener Like { get; } = new EventListener("like", showProgress: ShowProgress.Hidden, configData: () => new Dictionary<string, object> { { "likeable", false } }, callback: async (block) => block.Likeable = true, doc: "This listener is triggered when the user likes/dislikes from within the {{ component }}. This event has EventData of type gradio.LikeData that carries information, accessible through LikeData.index and LikeData.value. See EventData documentation on how to use this event data.");
+    internal static EventListener Load { get; } = new EventListener("load", doc: "This listener is triggered when the {{ component }} initially loads in the browser.");
+    internal static EventListener KeyUp { get; } = new EventListener("key_up", doc: "This listener is triggered when the user presses a key while the {{ component }} is focused.");
+    internal static EventListener Apply { get; } = new EventListener("apply", doc: "This listener is triggered when the user applies changes to the {{ component }} through an integrated UI action.");
 }

--- a/Gradio.Net/FileMiddleware.cs
+++ b/Gradio.Net/FileMiddleware.cs
@@ -1,36 +1,29 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Metadata.Ecma335;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class FileMiddleware
 {
-    internal class FileMiddleware
+    private readonly RequestDelegate _next;
+
+    public FileMiddleware(RequestDelegate next)
     {
-        private readonly RequestDelegate _next;
+        _next = next;
+    }
 
-        public FileMiddleware(RequestDelegate next)
-        {
-            _next = next;
-        }
-
-        public async Task InvokeAsync(HttpContext httpContext, App app)
-        {
-            var path = httpContext.Request.Path.ToString();
-            const string FILE_URL = "/file=";
-            if (path.StartsWith(FILE_URL)) {
-                (string filePath, string contentType) = await app.GetUploadedFile(path.Substring(FILE_URL.Length));
-                httpContext.Response.ContentType = contentType;
-                using (var fs = new FileStream(filePath, FileMode.Open))
-                {
-                    await fs.CopyToAsync(httpContext.Response.Body);
-                }
-                return;
+    public async Task InvokeAsync(HttpContext httpContext, App app)
+    {
+        string path = httpContext.Request.Path.ToString();
+        const string FILE_URL = "/file=";
+        if (path.StartsWith(FILE_URL)) {
+            (string filePath, string contentType) = await app.GetUploadedFile(path.Substring(FILE_URL.Length));
+            httpContext.Response.ContentType = contentType;
+            using (FileStream fs = new(filePath, FileMode.Open))
+            {
+                await fs.CopyToAsync(httpContext.Response.Body);
             }
-            await _next(httpContext);
+            return;
         }
+        await _next(httpContext);
     }
 }

--- a/Gradio.Net/FormComponents/Checkbox.cs
+++ b/Gradio.Net/FormComponents/Checkbox.cs
@@ -1,55 +1,47 @@
-﻿using Gradio.Net.Enums;
+﻿namespace Gradio.Net;
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-
-namespace Gradio.Net
+public class Checkbox : FormComponent
 {
-    public class Checkbox : FormComponent
+    internal Checkbox() { }
+    public static bool Payload(object obj)
     {
-        internal Checkbox() { }
-        public static bool Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return false;
-            }
-
-            if (obj is bool str)
-            {
-                return str;
-            }
-
-            throw new ArgumentException($"Payload Type expect bool actual {obj.GetType()}");
+            return false;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        if (obj is bool str)
         {
-            return new Dictionary<string, object>() { { "type", "bool" } };
+            return str;
         }
 
-        internal override object PreProcess(object data)
-        {            
-            if (data == null)
-            {
-                return false;
-            }
+        throw new ArgumentException($"Payload Type expect bool actual {obj.GetType()}");
+    }
 
-            var result = bool.Parse(data.ToString());
-            return result;
-        }
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "bool" } };
+    }
 
-        internal override object PostProcess(string rootUrl, object data)
+    internal override object PreProcess(object data)
+    {            
+        if (data == null)
         {
-            if (data == null)
-            {
-                return false;
-            }
-
-            var result = bool.Parse(data.ToString());
-            return result;
+            return false;
         }
+
+        bool result = bool.Parse(data.ToString());
+        return result;
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return false;
+        }
+
+        bool result = bool.Parse(data.ToString());
+        return result;
     }
 }

--- a/Gradio.Net/FormComponents/CheckboxGroup.cs
+++ b/Gradio.Net/FormComponents/CheckboxGroup.cs
@@ -1,101 +1,96 @@
 ﻿using Gradio.Net.Enums;
-
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class CheckboxGroup : FormComponent
 {
-    public class CheckboxGroup : FormComponent
+    internal CheckboxGroup() { }
+    internal IEnumerable<string> Choices { get;  set; }
+    internal CheckboxGroupType Type { get;  set; }
+
+    public static IEnumerable<string> Payload(object obj)
     {
-        internal CheckboxGroup() { }
-        internal IEnumerable<string> Choices { get;  set; }
-        internal CheckboxGroupType Type { get;  set; }
-
-        public static IEnumerable<string> Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is IEnumerable<string> list)
-            {
-                return list;
-            }
-
-            throw new ArgumentException($"Payload Type expect IEnumerable<string> actual {obj.GetType()}");
+            return null;
         }
 
-        protected override Dictionary<string, object> GetProps()
+        if (obj is IEnumerable<string> list)
         {
-            var result = base.GetProps();
-
-            result["choices"]= this.Choices.Select(x => new[] { x,x}).ToArray();
-
-            return result;
+            return list;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        throw new ArgumentException($"Payload Type expect IEnumerable<string> actual {obj.GetType()}");
+    }
+
+    protected override Dictionary<string, object> GetProps()
+    {
+        Dictionary<string, object> result = base.GetProps();
+
+        result["choices"]= this.Choices.Select(x => new[] { x,x}).ToArray();
+
+        return result;
+    }
+
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+
+    internal override object PreProcess(object data)
+    {
+        
+        if (data == null)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
+            return new List<string>();
         }
 
-        internal override object PreProcess(object data)
+        if (data is JsonElement element)
         {
-            
-            if (data == null)
+            if (element.ValueKind == JsonValueKind.String)
             {
-                return new List<string>();
+                return new[] { data.ToString() };
             }
 
-            if (data is JsonElement element)
+            if (element.ValueKind == JsonValueKind.Array)
             {
-                if (element.ValueKind == JsonValueKind.String)
-                {
-                    return new[] { data.ToString() };
-                }
-
-                if (element.ValueKind == JsonValueKind.Array)
-                {
-                    return JsonUtils.Deserialize<string[]>(data.ToString());
-                }
-
+                return JsonUtils.Deserialize<string[]>(data.ToString());
             }
-            var str = data.ToString();
 
-            var choices = JsonUtils.Deserialize<string[]>(str);
-            if (choices != null)
-            {
-                return choices; 
-            }
-            
-            return new[] { str };
+        }
+        string? str = data.ToString();
+
+        string[] choices = JsonUtils.Deserialize<string[]>(str);
+        if (choices != null)
+        {
+            return choices; 
+        }
+        
+        return new[] { str };
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return new List<string>();
         }
 
-        internal override object PostProcess(string rootUrl, object data)
+        if (data is IEnumerable<string>)
         {
-            if (data == null)
-            {
-                return new List<string>();
-            }
-
-            if (data is IEnumerable<string>)
-            {
-                return data;
-            }
-
-            var str = data.ToString();
-
-            var choices = JsonUtils.Deserialize<string[]>(str);
-            if (choices != null)
-            {
-                return choices;
-            }
-
-            return new[] { str };
+            return data;
         }
+
+        string? str = data.ToString();
+
+        string[] choices = JsonUtils.Deserialize<string[]>(str);
+        if (choices != null)
+        {
+            return choices;
+        }
+
+        return new[] { str };
     }
 }

--- a/Gradio.Net/FormComponents/Dropdown.cs
+++ b/Gradio.Net/FormComponents/Dropdown.cs
@@ -1,103 +1,98 @@
 ﻿using Gradio.Net.Enums;
-
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Dropdown : FormComponent
 {
-    public class Dropdown : FormComponent
+    internal Dropdown() { }
+    internal int? MaxChoices { get;  set; }
+    internal IEnumerable<string> Choices { get;  set; }
+    internal DropdownType Type { get;  set; }
+    internal bool? Multiselect { get;  set; }
+    internal bool AllowCustomValue { get;  set; }
+    internal bool Filterable { get;  set; }
+
+    public static IEnumerable<string> Payload(object obj)
     {
-        internal Dropdown() { }
-        internal int? MaxChoices { get;  set; }
-        internal IEnumerable<string> Choices { get;  set; }
-        internal DropdownType Type { get;  set; }
-        internal bool? Multiselect { get;  set; }
-        internal bool AllowCustomValue { get;  set; }
-        internal bool Filterable { get;  set; }
-
-        public static IEnumerable<string> Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is IEnumerable<string> list)
-            {
-                return list;
-            }
-
-            throw new ArgumentException($"Payload Type expect IEnumerable<string> actual {obj.GetType()}");
+            return null;
         }
 
-        protected override Dictionary<string, object> GetProps()
+        if (obj is IEnumerable<string> list)
         {
-            var result = base.GetProps();
-
-            result["choices"]= this.Choices.Select(x => new[] { x,x}).ToArray();
-
-            return result;
+            return list;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        throw new ArgumentException($"Payload Type expect IEnumerable<string> actual {obj.GetType()}");
+    }
+
+    protected override Dictionary<string, object> GetProps()
+    {
+        Dictionary<string, object> result = base.GetProps();
+
+        result["choices"]= this.Choices.Select(x => new[] { x,x}).ToArray();
+
+        return result;
+    }
+
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+
+    internal override object PreProcess(object data)
+    {
+        
+        if (data == null)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
+            return new List<string>();
         }
 
-        internal override object PreProcess(object data)
+        if (data is JsonElement element)
         {
-            
-            if (data == null)
+            if (element.ValueKind == JsonValueKind.String)
             {
-                return new List<string>();
+                return new[] { data.ToString() };
             }
 
-            if (data is JsonElement element)
+            if (element.ValueKind == JsonValueKind.Array)
             {
-                if (element.ValueKind == JsonValueKind.String)
-                {
-                    return new[] { data.ToString() };
-                }
-
-                if (element.ValueKind == JsonValueKind.Array)
-                {
-                    return JsonUtils.Deserialize<string[]>(data.ToString());
-                }
-
+                return JsonUtils.Deserialize<string[]>(data.ToString());
             }
-            var str = data.ToString();
 
-            var choices = JsonUtils.Deserialize<string[]>(str);
-            if (choices != null)
-            {
-                return choices; 
-            }
-            
-            return new[] { str };
+        }
+        string? str = data.ToString();
+
+        string[] choices = JsonUtils.Deserialize<string[]>(str);
+        if (choices != null)
+        {
+            return choices; 
+        }
+        
+        return new[] { str };
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return new List<string>();
+        }
+        if (data is IEnumerable<string>)
+        {
+            return data;
+        }
+        string? str = data.ToString();
+
+        string[] choices = JsonUtils.Deserialize<string[]>(str);
+        if (choices != null)
+        {
+            return choices;
         }
 
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            if (data == null)
-            {
-                return new List<string>();
-            }
-            if (data is IEnumerable<string>)
-            {
-                return data;
-            }
-            var str = data.ToString();
-
-            var choices = JsonUtils.Deserialize<string[]>(str);
-            if (choices != null)
-            {
-                return choices;
-            }
-
-            return new[] { str };
-        }
+        return new[] { str };
     }
 }

--- a/Gradio.Net/FormComponents/FormComponent.cs
+++ b/Gradio.Net/FormComponents/FormComponent.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class FormComponent : Component
 {
-    public class FormComponent : Component
-    {
-        internal FormComponent() { }
-    }
+    internal FormComponent() { }
 }

--- a/Gradio.Net/FormComponents/MultimodalTextbox.cs
+++ b/Gradio.Net/FormComponents/MultimodalTextbox.cs
@@ -1,67 +1,62 @@
 ﻿using Gradio.Net.Enums;
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 
+namespace Gradio.Net;
 
-namespace Gradio.Net
+public class MultimodalTextbox : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveSelectEvent, IHaveSubmitEvent, IHaveFocusEvent, IHaveBlurEvent
 {
-    public class MultimodalTextbox : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveSelectEvent, IHaveSubmitEvent, IHaveFocusEvent, IHaveBlurEvent
+    internal MultimodalTextbox() { }
+    internal object SubmitBtn { get;  set; }
+    internal int Lines { get;   set; }
+    internal int MaxLines { get;   set; }
+    internal string Placeholder { get;   set; }
+    internal bool Autofocus { get;  set; }
+    internal bool Autoscroll { get;  set; }
+    
+    internal TextboxTextAlign TextAlign { get;  set; }
+    
+
+    public static MultimodalData Payload(object obj)
     {
-        internal MultimodalTextbox() { }
-        internal object SubmitBtn { get;  set; }
-        internal int Lines { get;   set; }
-        internal int MaxLines { get;   set; }
-        internal string Placeholder { get;   set; }
-        internal bool Autofocus { get;  set; }
-        internal bool Autoscroll { get;  set; }
-        
-        internal TextboxTextAlign TextAlign { get;  set; }
-        
-
-        public static MultimodalData Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is MultimodalData str)
-            {
-                return str;
-            }
-
-            throw new ArgumentException($"Payload Type expect MultimodalData actual {obj.GetType()}");
+            return null;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        if (obj is MultimodalData str)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
+            return str;
         }
 
-        internal override object PreProcess(object data)
+        throw new ArgumentException($"Payload Type expect MultimodalData actual {obj.GetType()}");
+    }
+
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+
+    internal override object PreProcess(object data)
+    {
+        MultimodalData result = null;
+        if (data == null)
         {
-            MultimodalData result = null;
-            if (data == null)
-            {
-                return result;
-            }
-             
-            result = JsonUtils.Deserialize< MultimodalData>( data.ToString());
+            return result;
+        }
+         
+        result = JsonUtils.Deserialize< MultimodalData>( data.ToString());
+        return result;
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        MultimodalData result = null;
+        if (data == null)
+        {
             return result;
         }
 
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            MultimodalData result = null;
-            if (data == null)
-            {
-                return result;
-            }
-
-            result = JsonUtils.Deserialize<MultimodalData>(data.ToString());
-            return result;
-        }
+        result = JsonUtils.Deserialize<MultimodalData>(data.ToString());
+        return result;
     }
 }

--- a/Gradio.Net/FormComponents/Number.cs
+++ b/Gradio.Net/FormComponents/Number.cs
@@ -1,60 +1,52 @@
-﻿using Gradio.Net.Enums;
+﻿namespace Gradio.Net;
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-
-namespace Gradio.Net
+public class Number : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveSubmitEvent, IHaveFocusEvent
 {
-    public class Number : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveSubmitEvent, IHaveFocusEvent
+    internal Number() { }
+    internal decimal Step { get; set; }
+    internal int? Precision { get;  set; }
+    internal decimal? Minimum { get;  set; }
+    internal decimal? Maximum { get;  set; }
+
+    public static decimal? Payload(object obj)
     {
-        internal Number() { }
-        internal decimal Step { get; set; }
-        internal int? Precision { get;  set; }
-        internal decimal? Minimum { get;  set; }
-        internal decimal? Maximum { get;  set; }
-
-        public static decimal? Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is decimal str)
-            {
-                return str;
-            }
-
-            throw new ArgumentException($"Payload Type expect decimal actual {obj.GetType()}");
+            return null;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        if (obj is decimal str)
         {
-            return new Dictionary<string, object>() { { "type", "decimal" } };
+            return str;
         }
 
-        internal override object PreProcess(object data)
-        {            
-            if (data == null)
-            {
-                return null;
-            }
+        throw new ArgumentException($"Payload Type expect decimal actual {obj.GetType()}");
+    }
 
-            var result = decimal.Parse(data.ToString());
-            return result;
-        }
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "decimal" } };
+    }
 
-        internal override object PostProcess(string rootUrl, object data)
+    internal override object PreProcess(object data)
+    {            
+        if (data == null)
         {
-            if (data == null)
-            {
-                return null;
-            }
-
-            var result = decimal.Parse(data.ToString());
-            return result;
+            return null;
         }
+
+        decimal result = decimal.Parse(data.ToString());
+        return result;
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+
+        decimal result = decimal.Parse(data.ToString());
+        return result;
     }
 }

--- a/Gradio.Net/FormComponents/Radio.cs
+++ b/Gradio.Net/FormComponents/Radio.cs
@@ -1,102 +1,97 @@
 ﻿using Gradio.Net.Enums;
-
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Radio : FormComponent, IHaveChangeEvent, IHaveInputEvent,IHaveSelectEvent
 {
-    public class Radio : FormComponent, IHaveChangeEvent, IHaveInputEvent,IHaveSelectEvent
+    internal Radio() { }
+    internal IEnumerable<string> Choices { get;  set; }
+    internal RadioType Type { get;  set; }
+
+    public static IEnumerable<string> Payload(object obj)
     {
-        internal Radio() { }
-        internal IEnumerable<string> Choices { get;  set; }
-        internal RadioType Type { get;  set; }
-
-        public static IEnumerable<string> Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is IEnumerable<string> list)
-            {
-                return list;
-            }
-
-            throw new ArgumentException($"Payload Type expect IEnumerable<string> actual {obj.GetType()}");
+            return null;
         }
 
-        protected override Dictionary<string, object> GetProps()
+        if (obj is IEnumerable<string> list)
         {
-            var result = base.GetProps();
-
-            result["choices"]= this.Choices.Select(x => new[] { x,x}).ToArray();
-
-            return result;
+            return list;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
-        {
-            return new Dictionary<string, object>() { { "type", "string" } };
-        }
-
-        internal override object PreProcess(object data)
-        {
-            
-            if (data == null)
-            {
-                return new List<string>();
-            }
-
-            if (data is JsonElement element)
-            {
-                if (element.ValueKind == JsonValueKind.String)
-                {
-                    return new[] { data.ToString() };
-                }
-
-                if (element.ValueKind == JsonValueKind.Array)
-                {
-                    return JsonUtils.Deserialize<string[]>(data.ToString());
-                }
-
-            }
-            var str = data.ToString();
-
-            var choices = JsonUtils.Deserialize<string[]>(str);
-            if (choices != null)
-            {
-                return choices; 
-            }
-            
-            return new[] { str };
-        }
-
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            if (data == null)
-            {
-                return new List<string>();
-            }
-            if (data is IEnumerable<string>)
-            {
-                return data;
-            }
-
-            var str = data.ToString();
-
-            var choices = JsonUtils.Deserialize<string[]>(str);
-            if (choices != null)
-            {
-                return choices;
-            }
-
-            return new[] { str };
-        }
-
-
+        throw new ArgumentException($"Payload Type expect IEnumerable<string> actual {obj.GetType()}");
     }
+
+    protected override Dictionary<string, object> GetProps()
+    {
+        Dictionary<string, object> result = base.GetProps();
+
+        result["choices"]= this.Choices.Select(x => new[] { x,x}).ToArray();
+
+        return result;
+    }
+
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+
+    internal override object PreProcess(object data)
+    {
+        
+        if (data == null)
+        {
+            return new List<string>();
+        }
+
+        if (data is JsonElement element)
+        {
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                return new[] { data.ToString() };
+            }
+
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                return JsonUtils.Deserialize<string[]>(data.ToString());
+            }
+
+        }
+        string? str = data.ToString();
+
+        string[] choices = JsonUtils.Deserialize<string[]>(str);
+        if (choices != null)
+        {
+            return choices; 
+        }
+        
+        return new[] { str };
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return new List<string>();
+        }
+        if (data is IEnumerable<string>)
+        {
+            return data;
+        }
+
+        string? str = data.ToString();
+
+        string[] choices = JsonUtils.Deserialize<string[]>(str);
+        if (choices != null)
+        {
+            return choices;
+        }
+
+        return new[] { str };
+    }
+
+
 }

--- a/Gradio.Net/FormComponents/Slider.cs
+++ b/Gradio.Net/FormComponents/Slider.cs
@@ -1,74 +1,66 @@
-﻿using Gradio.Net.Enums;
+﻿namespace Gradio.Net;
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
-
-namespace Gradio.Net
+public class Slider : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveReleaseEvent
 {
-    public class Slider : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveReleaseEvent
+    internal Slider() { }
+    internal decimal Step { get; set; }
+    internal decimal Minimum { get;  set; }
+    internal decimal Maximum { get;  set; }
+
+    public static decimal Payload(object obj)
     {
-        internal Slider() { }
-        internal decimal Step { get; set; }
-        internal decimal Minimum { get;  set; }
-        internal decimal Maximum { get;  set; }
-
-        public static decimal Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return decimal.MinValue;
-            }
-
-            if (obj is decimal str)
-            {
-                return str;
-            }
-
-            throw new ArgumentException($"Payload Type expect decimal actual {obj.GetType()}");
+            return decimal.MinValue;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        if (obj is decimal str)
         {
-            return new Dictionary<string, object>() { { "type", "decimal" } };
+            return str;
         }
 
-        internal decimal GetRandomValue()
+        throw new ArgumentException($"Payload Type expect decimal actual {obj.GetType()}");
+    }
+
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "decimal" } };
+    }
+
+    internal decimal GetRandomValue()
+    {
+        int nSteps = (int)((Maximum - Minimum) / Step);
+        Random random = new();
+        int step = random.Next(0, nSteps);
+        decimal value = Minimum + Step * Step;
+        int nDecimals = Math.Max(step.ToString().Reverse().ToList().IndexOf('.') + 1, 0);
+        if (nDecimals > 0)
         {
-            int nSteps = (int)((Maximum - Minimum) / Step);
-            Random random = new Random();
-            int step = random.Next(0, nSteps);
-            var value = Minimum + Step * Step;
-            int nDecimals = Math.Max(step.ToString().Reverse().ToList().IndexOf('.') + 1, 0);
-            if (nDecimals > 0)
-            {
-                value = Math.Round(value, nDecimals);
-            }
-            return value;
-
+            value = Math.Round(value, nDecimals);
         }
+        return value;
 
-        internal override object PreProcess(object data)
-        {            
-            if (data == null)
-            {
-                return decimal.MinValue;
-            }
+    }
 
-            var result = decimal.Parse(data.ToString());
-            return result;
-        }
-
-        internal override object PostProcess(string rootUrl, object data)
+    internal override object PreProcess(object data)
+    {            
+        if (data == null)
         {
-            if (data == null)
-            {
-                return decimal.MinValue;
-            }
-
-            var result = decimal.Parse(data.ToString());
-            return result;
+            return decimal.MinValue;
         }
+
+        decimal result = decimal.Parse(data.ToString());
+        return result;
+    }
+
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return decimal.MinValue;
+        }
+
+        decimal result = decimal.Parse(data.ToString());
+        return result;
     }
 }

--- a/Gradio.Net/FormComponents/Textbox.cs
+++ b/Gradio.Net/FormComponents/Textbox.cs
@@ -1,64 +1,59 @@
 ﻿using Gradio.Net.Enums;
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 
+namespace Gradio.Net;
 
-namespace Gradio.Net
+public class Textbox : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveSelectEvent, IHaveSubmitEvent, IHaveFocusEvent, IHaveBlurEvent
 {
-    public class Textbox : FormComponent, IHaveChangeEvent, IHaveInputEvent, IHaveSelectEvent, IHaveSubmitEvent, IHaveFocusEvent, IHaveBlurEvent
+    internal Textbox() { }
+    internal int Lines { get;   set; }
+    internal int MaxLines { get;   set; }
+    internal string Placeholder { get;   set; }
+    internal bool Autofocus { get;  set; }
+    internal bool Autoscroll { get;  set; }
+    internal TextboxType Type { get;  set; }
+    internal TextboxTextAlign TextAlign { get;  set; }
+    internal bool ShowCopyButton { get;  set; }
+
+    public static string Payload(object obj)
     {
-        internal Textbox() { }
-        internal int Lines { get;   set; }
-        internal int MaxLines { get;   set; }
-        internal string Placeholder { get;   set; }
-        internal bool Autofocus { get;  set; }
-        internal bool Autoscroll { get;  set; }
-        internal TextboxType Type { get;  set; }
-        internal TextboxTextAlign TextAlign { get;  set; }
-        internal bool ShowCopyButton { get;  set; }
-
-        public static string Payload(object obj)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            if (obj is string str)
-            {
-                return str;
-            }
-
-            throw new ArgumentException($"Payload Type expect string actual {obj.GetType()}");
+            return null;
         }
 
-        protected override Dictionary<string, object> GetApiInfo()
+        if (obj is string str)
         {
-            return new Dictionary<string, object>() { { "type", "string" } };
+            return str;
         }
 
-        internal override object PreProcess(object data)
-        {
-            string result = null;
-            if (data == null)
-            {
-                return result;
-            }
+        throw new ArgumentException($"Payload Type expect string actual {obj.GetType()}");
+    }
 
-            result = data.ToString();
+    protected override Dictionary<string, object> GetApiInfo()
+    {
+        return new Dictionary<string, object>() { { "type", "string" } };
+    }
+
+    internal override object PreProcess(object data)
+    {
+        string result = null;
+        if (data == null)
+        {
             return result;
         }
 
-        internal override object PostProcess(string rootUrl, object data)
-        {
-            if (data == null)
-            {
-                return null;
-            }
+        result = data.ToString();
+        return result;
+    }
 
-            return data.ToString();
+    internal override object PostProcess(string rootUrl, object data)
+    {
+        if (data == null)
+        {
+            return null;
         }
+
+        return data.ToString();
     }
 }

--- a/Gradio.Net/GradioServiceConfig.cs
+++ b/Gradio.Net/GradioServiceConfig.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class GradioServiceConfig
 {
-    public class GradioServiceConfig
-    {
-    }
 }

--- a/Gradio.Net/GradioServiceExtensions.cs
+++ b/Gradio.Net/GradioServiceExtensions.cs
@@ -1,121 +1,117 @@
 ﻿
 using Gradio.Net;
 using Gradio.Net.jinja2;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using static System.Runtime.CompilerServices.YieldAwaitable;
 using Gradio.Net.Models;
 
 
-namespace Microsoft.AspNetCore.Builder
+namespace Microsoft.AspNetCore.Builder;
+
+public static class GradioServiceExtensions
 {
-    public static class GradioServiceExtensions
+    
+    public static IServiceCollection AddGradio(this IServiceCollection services)
     {
-        
-        public static IServiceCollection AddGradio(this IServiceCollection services)
+        services.AddSingleton<App>(new App());
+        services.AddHostedService<EventWorker>();
+        return services;
+    }
+
+    public static WebApplication UseGradio(this WebApplication webApplication
+    , Blocks blocks, Action<GradioServiceConfig>? additionalConfigurationAction = null)
+    {
+        webApplication.UseMiddleware<FileMiddleware>();
+
+        GradioServiceConfig gradioServiceConfig = new();
+        additionalConfigurationAction?.Invoke(gradioServiceConfig);
+
+        App app = webApplication.Services.GetRequiredService<App>();
+
+        app.SetConfig(gradioServiceConfig);
+
+        StaticFileProvider fileProvider = new(@"templates/frontend");
+        webApplication.UseStaticFiles(new StaticFileOptions
         {
-            services.AddSingleton<App>(new App());
-            services.AddHostedService<EventWorker>();
-            return services;
-        }
+            FileProvider = fileProvider
+        });
 
-        public static WebApplication UseGradio(this WebApplication webApplication
-        , Blocks blocks, Action<GradioServiceConfig>? additionalConfigurationAction = null)
+        webApplication.MapGet("/", (HttpRequest request, [FromServices] App app) =>
         {
-            webApplication.UseMiddleware<FileMiddleware>();
+            Template template = new(new StreamReader(fileProvider.GetFileInfo("index.html").CreateReadStream()).ReadToEnd());
+            return Results.Content(template.Render(new Dictionary<string, object>() { { "config", app.GetConfig(request) } }), "text/html");
+        });
 
-            GradioServiceConfig gradioServiceConfig = new GradioServiceConfig();
-            additionalConfigurationAction?.Invoke(gradioServiceConfig);
+        webApplication.MapGet("/config", (HttpRequest request, [FromServices] App app) =>
+        {
+            return app.GetConfig(request);
+        });
 
-            var app = webApplication.Services.GetRequiredService<App>();
+        webApplication.MapGet("/info", (HttpRequest request, [FromServices] App app) =>
+        {
+            return app.GetApiInfo(request);
+        });
 
-            app.SetConfig(gradioServiceConfig);
+        webApplication.MapPost("/queue/join", async (HttpRequest request, PredictBodyIn body, [FromServices] App app) =>
+        {
+            return await app.QueueJoin(request, body);
+        });
 
-            var fileProvider = new StaticFileProvider(@"templates/frontend");
-            webApplication.UseStaticFiles(new StaticFileOptions
-            {
-                FileProvider = fileProvider
-            });
-
-            webApplication.MapGet("/", (HttpRequest request, [FromServices] App app) =>
-            {
-                var template = new Template(new StreamReader(fileProvider.GetFileInfo("index.html").CreateReadStream()).ReadToEnd());
-                return Results.Content(template.Render(new Dictionary<string, object>() { { "config", app.GetConfig(request) } }), "text/html");
-            });
-
-            webApplication.MapGet("/config", (HttpRequest request, [FromServices] App app) =>
-            {
-                return app.GetConfig(request);
-            });
-
-            webApplication.MapGet("/info", (HttpRequest request, [FromServices] App app) =>
-            {
-                return app.GetApiInfo(request);
-            });
-
-            webApplication.MapPost("/queue/join", async (HttpRequest request, PredictBodyIn body, [FromServices] App app) =>
-            {
-                return await app.QueueJoin(request, body);
-            });
-
-            webApplication.MapGet("/queue/data", async ([FromServices] App app,HttpContext context, CancellationToken stoppingToken) =>
-                {
-                    context.Response.Headers.Add("Content-Type", "text/event-stream");
-
-
-                    StreamWriter streamWriter = new StreamWriter(context.Response.Body);
-                    await foreach (var message in app.QueueData(context.Request.Query["session_hash"].FirstOrDefault(), stoppingToken))
-                    {
-                        await streamWriter.WriteLineAsync(message.ProcessMsg());
-                        await streamWriter.FlushAsync();
-                    }
-                    await streamWriter.WriteLineAsync(new CloseStreamMessage().ProcessMsg());
-                    await streamWriter.FlushAsync();
-
-                });
-
-            webApplication.MapPost("/upload", async (HttpRequest request,  [FromServices] App app) =>
-            {
-                var uploadId = request.Query["upload_id"].First();
-                var files = request.Form.Files;
-                return await app.Upload(uploadId, files);
-            });
-
-            webApplication.MapGet("/upload_progress", async ([FromServices] App app, HttpContext context, CancellationToken stoppingToken) =>
+        webApplication.MapGet("/queue/data", async ([FromServices] App app,HttpContext context, CancellationToken stoppingToken) =>
             {
                 context.Response.Headers.Add("Content-Type", "text/event-stream");
-                
-                StreamWriter streamWriter = new StreamWriter(context.Response.Body);
 
+
+                StreamWriter streamWriter = new(context.Response.Body);
+                await foreach (SSEMessage message in app.QueueData(context.Request.Query["session_hash"].FirstOrDefault(), stoppingToken))
+                {
+                    await streamWriter.WriteLineAsync(message.ProcessMsg());
+                    await streamWriter.FlushAsync();
+                }
                 await streamWriter.WriteLineAsync(new CloseStreamMessage().ProcessMsg());
                 await streamWriter.FlushAsync();
+
             });
 
-           
-
-            webApplication.MapGet("/file", async ([FromServices] App app, HttpContext context) =>
-            {
-                return context.Request.Path;
-                //await app.GetUploadedFile(pathOrUrl);
-            });
-
-            return webApplication;
-        }
-
-        private static Dictionary<string, object> GetConfig(HttpRequest request)
+        webApplication.MapPost("/upload", async (HttpRequest request,  [FromServices] App app) =>
         {
-            var config = new Dictionary<string, object>();
-            return config;
-        }
+            string? uploadId = request.Query["upload_id"].First();
+            IFormFileCollection files = request.Form.Files;
+            return await app.Upload(uploadId, files);
+        });
 
-        private static string GetTemplate(string rootPath)
+        webApplication.MapGet("/upload_progress", async ([FromServices] App app, HttpContext context, CancellationToken stoppingToken) =>
         {
-            var file = Path.Combine(rootPath, @"templates\frontend\index.html");
+            context.Response.Headers.Add("Content-Type", "text/event-stream");
+            
+            StreamWriter streamWriter = new(context.Response.Body);
 
-            return File.ReadAllText(file);
-        }
+            await streamWriter.WriteLineAsync(new CloseStreamMessage().ProcessMsg());
+            await streamWriter.FlushAsync();
+        });
+
+       
+
+        webApplication.MapGet("/file", async ([FromServices] App app, HttpContext context) =>
+        {
+            return context.Request.Path;
+            //await app.GetUploadedFile(pathOrUrl);
+        });
+
+        return webApplication;
+    }
+
+    private static Dictionary<string, object> GetConfig(HttpRequest request)
+    {
+        Dictionary<string, object> config = [];
+        return config;
+    }
+
+    private static string GetTemplate(string rootPath)
+    {
+        string file = Path.Combine(rootPath, @"templates\frontend\index.html");
+
+        return File.ReadAllText(file);
     }
 }

--- a/Gradio.Net/Helpers/Progress.cs
+++ b/Gradio.Net/Helpers/Progress.cs
@@ -1,46 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Helpers;
 
-namespace Gradio.Net.Helpers
+public class Progress
 {
-    public class Progress
+    internal Progress(int total)
     {
-        internal Progress(int total)
+        if (total <= 0)
         {
-            if (total <= 0)
-            {
-                throw new ArgumentException("total must be grater than zero");
-            }
-
-            Length = total;
+            throw new ArgumentException("total must be grater than zero");
         }
 
-        internal string Unit { get; set; } = "steps";
-        internal string Desc { get; set; }
-        internal int Index { get; set; }
-        internal int Length { get; set; }
+        Length = total;
+    }
 
-        public void Report(
-            int value,
-            string desc=null,
-            int? total=null,
-            string unit= "steps"            
-        )
+    internal string Unit { get; set; } = "steps";
+    internal string Desc { get; set; }
+    internal int Index { get; set; }
+    internal int Length { get; set; }
+
+    public void Report(
+        int value,
+        string desc=null,
+        int? total=null,
+        string unit= "steps"            
+    )
+    {
+        Index = value;
+        if (desc != null)
         {
-            Index = value;
-            if (desc != null)
-            {
-                Desc = desc;
-            }
-            if (total != null)
-            {
-                Length = total.Value;
-            }
-            Unit = unit;
+            Desc = desc;
         }
+        if (total != null)
+        {
+            Length = total.Value;
+        }
+        Unit = unit;
     }
 }

--- a/Gradio.Net/Layouts/Accordion.cs
+++ b/Gradio.Net/Layouts/Accordion.cs
@@ -1,15 +1,8 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public class Accordion : Blocks
 {
-    public class Accordion : Blocks
-    {
-        internal Accordion() { }
-        internal string Label { get;  set; }
-        internal bool Open { get;  set; }
-    }
+    internal Accordion() { }
+    internal string Label { get;  set; }
+    internal bool Open { get;  set; }
 }

--- a/Gradio.Net/Layouts/Blocks.cs
+++ b/Gradio.Net/Layouts/Blocks.cs
@@ -1,353 +1,351 @@
 ﻿
 using Gradio.Net.Enums;
-using Microsoft.AspNetCore.Components.Forms;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Xml.Linq;
 
 using FnTarget = (int? Id, string EventName);
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Blocks : Block, IList<Block>, IDisposable
 {
-    public class Blocks : Block, IList<Block>, IDisposable
+    private readonly List<Block> _children = [];
+    internal Blocks()
     {
-        private readonly List<Block> _children = new List<Block>();
-        internal Blocks()
+    }
+    [IgnoreDataMember]
+    internal Blocks ParentBlocks { get; set; }
+
+    public int Count => _children.Count;
+
+    public bool IsReadOnly => false;
+
+    internal string Title { get; set; }
+    internal string Theme { get;  set; }
+    internal bool? AnalyticsEnabled { get;  set; }
+    internal string Mode { get;  set; }
+    internal string Css { get;  set; }
+    internal string Js { get;  set; }
+    internal string Head { get;  set; }
+    internal bool? FillHeight { get;  set; }
+    internal Tuple<int, int> DeleteCache { get;  set; }
+    
+    public  virtual void Add(Block item)
+    {
+        if (item is Blocks blocks)
         {
+            blocks.ParentBlocks = this;
         }
-        [IgnoreDataMember]
-        internal Blocks ParentBlocks { get; set; }
+        _children.Add(item);
+    }
 
-        public int Count => _children.Count;
+    public void Clear()
+    {
+        _children.Clear();
+    }
 
-        public bool IsReadOnly => false;
+    public bool Contains(Block item)
+    {
+        return _children.Contains(item);
+    }
 
-        internal string Title { get; set; }
-        internal string Theme { get;  set; }
-        internal bool? AnalyticsEnabled { get;  set; }
-        internal string Mode { get;  set; }
-        internal string Css { get;  set; }
-        internal string Js { get;  set; }
-        internal string Head { get;  set; }
-        internal bool? FillHeight { get;  set; }
-        internal Tuple<int, int> DeleteCache { get;  set; }
-        
-        public  virtual void Add(Block item)
+    public void CopyTo(Block[] array, int arrayIndex)
+    {
+        _children.CopyTo(array, arrayIndex);
+    }
+
+    public virtual void Dispose()
+    {
+        Context.SetCurrentBlocks(null);
+    }
+
+    internal Dictionary<string, object> GetConfig()
+    {
+
+        Dictionary<string, object> config = new()
         {
+            ["mode"] = this.Mode,
+            ["dev_mode"] = false,
+            ["analytics_enabled"] = this.AnalyticsEnabled,
+            ["components"] = GetComponents(),
+            ["css"] = this.Css,
+            ["connect_heartbeat"] = false,
+            ["js"] = this.Js,
+            ["head"] = this.Head,
+            ["title"] = this.Title,
+            ["space_id"] = null,
+            ["enable_queue"] = true,
+            ["show_error"] = false,
+            ["show_api"] = true,
+            ["is_colab"] = false,
+            ["max_file_size"] = null,
+            ["stylesheets"] = new string[] {
+            "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap",
+            "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap"
+        },
+            ["theme"] = this.Theme,
+            ["protocol"] = "sse_v3",
+            ["body_css"] = new Dictionary<string, object> {
+            { "body_background_fill", "white" },
+            { "body_text_color", "#1f2937" },
+            { "body_background_fill_dark", "#0b0f19" },
+            { "body_text_color_dark", "#f3f4f6" },
+        },
+            ["fill_height"] = this.FillHeight,
+
+            ["layout"] = GetLayout(),
+
+
+
+            ["dependencies"] = GetDependencies()
+        };
+
+        return config;
+    }
+
+    internal List<Dictionary<string, object>> GetComponents()
+    {
+        List<Dictionary<string, object>> result = [];
+        foreach (Block item in _children)
+        {
+            result.Add(item.GetConfig());
             if (item is Blocks blocks)
             {
-                blocks.ParentBlocks = this;
+                
+                result.AddRange(blocks.GetComponents());
             }
-            _children.Add(item);
         }
 
-        public void Clear()
+        return result;
+    }
+
+    internal override Dictionary<string, object> GetLayout()
+    {
+        Dictionary<string, object> result = new()
         {
-            _children.Clear();
+            ["id"] = Id
+        };
+        List<Dictionary<string, object>> childrenLayout = [];
+        foreach (Block item in _children)
+        {
+            childrenLayout.Add(item.GetLayout());
+        }
+        result["children"] = childrenLayout;
+
+        return result;
+    }
+
+    public IEnumerator<Block> GetEnumerator()
+    {
+        return _children.GetEnumerator();
+    }
+
+    public bool Remove(Block item)
+    {
+        return _children.Remove(item);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _children.GetEnumerator();
+    }
+
+    internal (BlockFunction, int) SetEventTrigger(
+        IEnumerable<EventListenerMethod> targets,
+        Func<Input,Task<Output>> fn = null,
+        Func<Input,IAsyncEnumerable<Output>> streamingFn = null,
+        IEnumerable<Component> inputs = null,
+        IEnumerable<Component> outputs = null,
+        bool preprocess = true,
+        bool postprocess = true,
+        bool scrollToOutput = false,
+        ShowProgress showProgress = ShowProgress.Full,
+        string apiName = null,
+        string js = null,
+        bool no_target = false,
+        bool? queue = null,
+        bool batch = false,
+        int maxBatchSize = 4,
+        List<int> cancels = null,
+        decimal? every = null,
+        bool? collects_event_data = null,
+        int? trigger_after = null,
+        bool trigger_only_on_success = false,
+        TriggerMode? triggerMode = TriggerMode.Once,
+        ConcurrencyLimit? concurrencyLimit = null,
+        string concurrencyId = null,
+        bool showApi = true)
+    {
+        // Support for singular parameter
+        List<FnTarget> tmpTargets = targets.Select(target => (!no_target && target.Block != null) ? new FnTarget(target.Block.Id, target.EventName) : new FnTarget(null,target.EventName)).ToList();
+
+        inputs = inputs == null ? [] : inputs.ToList();
+        outputs = outputs == null ? [] : outputs.ToList();
+
+        if (fn != null && (cancels == null || cancels.Count == 0))
+        {
+            //todo:
+            //CheckFunctionInputsMatch(fn, inputs);
         }
 
-        public bool Contains(Block item)
+        if (every != null && every <= 0)
         {
-            return _children.Contains(item);
+            throw new ArgumentException("Parameter 'every' must be positive or null");
         }
 
-        public void CopyTo(Block[] array, int arrayIndex)
+        if (every != null && batch)
         {
-            _children.CopyTo(array, arrayIndex);
+            throw new ArgumentException($"Cannot run event in a batch and every {every} seconds. Either batch is true or every is non-zero but not both.");
         }
 
-        public virtual void Dispose()
+        if (every != null && fn != null)
         {
-            Context.SetCurrentBlocks(null);
+            throw new NotImplementedException($"every {every} for fn");
+            //todo:
+            //fn = GetContinuousFn(fn, every.Value);
+        }
+        else if (every != null)
+        {
+            throw new ArgumentException("Cannot set a value for 'every' without a 'fn'.");
         }
 
-        internal Dictionary<string, object> GetConfig()
+        if (every != null && concurrencyLimit != null)
         {
-
-            var config = new Dictionary<string, object>();
-            config["mode"] = this.Mode;
-            config["dev_mode"] = false;
-            config["analytics_enabled"] = this.AnalyticsEnabled;
-            config["components"] = GetComponents();
-            config["css"] = this.Css;
-            config["connect_heartbeat"] = false;
-            config["js"] = this.Js;
-            config["head"] = this.Head;
-            config["title"] = this.Title;
-            config["space_id"] = null;
-            config["enable_queue"] = true;
-            config["show_error"] = false;
-            config["show_api"] = true;
-            config["is_colab"] = false;
-            config["max_file_size"] = null;
-            config["stylesheets"] = new string[] {
-                "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap",
-                "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap"
-            };
-            config["theme"] = this.Theme;
-            config["protocol"] = "sse_v3";
-            config["body_css"] = new Dictionary<string, object> {
-                { "body_background_fill", "white" },
-                { "body_text_color", "#1f2937" },
-                { "body_background_fill_dark", "#0b0f19" },
-                { "body_text_color_dark", "#f3f4f6" },
-            };
-            config["fill_height"] = this.FillHeight;
-
-            config["layout"] = GetLayout();
-
-            
-
-            config["dependencies"] = GetDependencies();
-
-            return config;
-        }
-
-        internal List<Dictionary<string, object>> GetComponents()
-        {
-            var result = new List<Dictionary<string, object>>();
-            foreach (var item in _children)
+            if (concurrencyLimit == ConcurrencyLimit.Default)
             {
-                result.Add(item.GetConfig());
-                if (item is Blocks blocks)
-                {
-                    
-                    result.AddRange(blocks.GetComponents());
-                }
-            }
-
-            return result;
-        }
-
-        internal override Dictionary<string, object> GetLayout()
-        {
-            var result = new Dictionary<string, object>();
-            result["id"] = Id;
-            var childrenLayout = new List<Dictionary<string, object>>();
-            foreach (var item in _children)
-            {
-                childrenLayout.Add(item.GetLayout());
-            }
-            result["children"] = childrenLayout;
-
-            return result;
-        }
-
-        public IEnumerator<Block> GetEnumerator()
-        {
-            return _children.GetEnumerator();
-        }
-
-        public bool Remove(Block item)
-        {
-            return _children.Remove(item);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return _children.GetEnumerator();
-        }
-
-        internal (BlockFunction, int) SetEventTrigger(
-            IEnumerable<EventListenerMethod> targets,
-            Func<Input,Task<Output>> fn = null,
-            Func<Input,IAsyncEnumerable<Output>> streamingFn = null,
-            IEnumerable<Component> inputs = null,
-            IEnumerable<Component> outputs = null,
-            bool preprocess = true,
-            bool postprocess = true,
-            bool scrollToOutput = false,
-            ShowProgress showProgress = ShowProgress.Full,
-            string apiName = null,
-            string js = null,
-            bool no_target = false,
-            bool? queue = null,
-            bool batch = false,
-            int maxBatchSize = 4,
-            List<int> cancels = null,
-            decimal? every = null,
-            bool? collects_event_data = null,
-            int? trigger_after = null,
-            bool trigger_only_on_success = false,
-            TriggerMode? triggerMode = TriggerMode.Once,
-            ConcurrencyLimit? concurrencyLimit = null,
-            string concurrencyId = null,
-            bool showApi = true)
-        {
-            // Support for singular parameter
-            List<FnTarget> tmpTargets = targets.Select(target => (!no_target && target.Block != null) ? new FnTarget(target.Block.Id, target.EventName) : new FnTarget(null,target.EventName)).ToList();
-
-            inputs = inputs == null ? new List<Component>() : inputs.ToList();
-            outputs = outputs == null ? new List<Component>() : outputs.ToList();
-
-            if (fn != null && (cancels == null || cancels.Count == 0))
-            {
-                //todo:
-                //CheckFunctionInputsMatch(fn, inputs);
-            }
-
-            if (every != null && every <= 0)
-            {
-                throw new ArgumentException("Parameter 'every' must be positive or null");
-            }
-
-            if (every != null && batch)
-            {
-                throw new ArgumentException($"Cannot run event in a batch and every {every} seconds. Either batch is true or every is non-zero but not both.");
-            }
-
-            if (every != null && fn != null)
-            {
-                throw new NotImplementedException($"every {every} for fn");
-                //todo:
-                //fn = GetContinuousFn(fn, every.Value);
-            }
-            else if (every != null)
-            {
-                throw new ArgumentException("Cannot set a value for 'every' without a 'fn'.");
-            }
-
-            if (every != null && concurrencyLimit != null)
-            {
-                if (concurrencyLimit == ConcurrencyLimit.Default)
-                {
-                    concurrencyLimit = null;
-                }
-                else
-                {
-                    throw new ArgumentException("Cannot set a value for 'concurrencyLimit' with 'every'.");
-                }
-            }
-
-            if (tmpTargets[0].EventName == "change" || tmpTargets[0].EventName == "key_up")
-            {
-                triggerMode ??= TriggerMode.AlwaysLast;
+                concurrencyLimit = null;
             }
             else
             {
-                triggerMode ??= TriggerMode.Once;
+                throw new ArgumentException("Cannot set a value for 'concurrencyLimit' with 'every'.");
             }
-
-            (IList _, int? progressIndex, int? eventDataIndex) = fn != null ? SpecialArgs(fn) : (null, null, null);
-
-            if (apiName != null && apiName.Trim() == "") {
-                if (fn != null)
-                {
-                    apiName = "unnamed";
-                }
-                else if (js != null)
-                {
-                    apiName = "js_fn";
-                    showApi = false;
-                }
-                else
-                {
-                    apiName = "unnamed";
-                    showApi = false;
-                }
-            }
-
-            if (collects_event_data == null)
-            {
-                collects_event_data = eventDataIndex != null;
-            }
-
-            if (fn == null && streamingFn == null)
-            {
-                throw new InvalidOperationException("Please set fn or streamingFn");
-            }
-            if (fn != null && streamingFn != null)
-            {
-                throw new InvalidOperationException("Please set fn or streamingFn");
-            }
-
-            var blockFn = new BlockFunction()
-            {
-                Fn= fn,
-                StreamingFn= streamingFn,
-                Inputs=inputs,
-                Outputs =outputs,
-                Preprocess=preprocess,
-                Postprocess=postprocess,
-                InputsAsDict = false,
-                Targets = tmpTargets,
-                Batch = batch,
-                MaxBatchSize = maxBatchSize,
-                ConcurrencyLimit = concurrencyLimit,
-                ConcurrencyId = concurrencyId,
-                TracksProgress = progressIndex!=null,
-                ApiName = apiName,
-                Js = js,
-                ShowProgress = showProgress,
-                Every = every,
-                Cancels = cancels,
-                CollectsEventData = collects_event_data,
-                TriggerAfter = trigger_after,
-                TriggerOnlyOnSuccess = trigger_only_on_success,
-                TriggerMode = triggerMode,
-                Queue = queue,
-                ScrollToOutput = scrollToOutput,
-                ShowApi = showApi
-            };
-
-            this.Fns.Add(blockFn);
-            return (blockFn, this.Fns.Count - 1);
         }
 
-        internal IEnumerable<Dictionary<string, object>> GetDependencies()
+        if (tmpTargets[0].EventName == "change" || tmpTargets[0].EventName == "key_up")
         {
-            var result = new List<Dictionary<string, object>>();
-            foreach (var func in Fns)
+            triggerMode ??= TriggerMode.AlwaysLast;
+        }
+        else
+        {
+            triggerMode ??= TriggerMode.Once;
+        }
+
+        (IList _, int? progressIndex, int? eventDataIndex) = fn != null ? SpecialArgs(fn) : (null, null, null);
+
+        if (apiName != null && apiName.Trim() == "") {
+            if (fn != null)
             {
-                result.Add(func.GetConfig());
+                apiName = "unnamed";
             }
-
-            return result;
-        }
-
-        [IgnoreDataMember]
-        internal List<BlockFunction> Fns { get; set; } = new List<BlockFunction>();
-
-        public Block this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        private (IList, int? progressIndex, int? eventDataIndex) SpecialArgs(Func<Input,Task<Output>> fn)
-        {
-            //todo:Checks if function has special arguments Request or EventData (via annotation) or Progress (via default value).
-            return (null, null, null);
-        }
-
-        protected override Dictionary<string, object> GetProps()
-        {
-            var result = base.GetProps();
-            if (result.ContainsKey("id"))
+            else if (js != null)
             {
-                result.Remove("id");
+                apiName = "js_fn";
+                showApi = false;
             }
-
-            if (result.ContainsKey("elem_classes"))
+            else
             {
-                result.Remove("elem_classes");
+                apiName = "unnamed";
+                showApi = false;
             }
-
-            return result;
         }
 
-        public int IndexOf(Block item)
+        if (collects_event_data == null)
         {
-            return _children.IndexOf(item);
+            collects_event_data = eventDataIndex != null;
         }
 
-        public void Insert(int index, Block item)
+        if (fn == null && streamingFn == null)
         {
-            _children.Insert(index, item);
+            throw new InvalidOperationException("Please set fn or streamingFn");
+        }
+        if (fn != null && streamingFn != null)
+        {
+            throw new InvalidOperationException("Please set fn or streamingFn");
         }
 
-        public void RemoveAt(int index)
+        BlockFunction blockFn = new()
         {
-           _children.RemoveAt(index);
+            Fn= fn,
+            StreamingFn= streamingFn,
+            Inputs=inputs,
+            Outputs =outputs,
+            Preprocess=preprocess,
+            Postprocess=postprocess,
+            InputsAsDict = false,
+            Targets = tmpTargets,
+            Batch = batch,
+            MaxBatchSize = maxBatchSize,
+            ConcurrencyLimit = concurrencyLimit,
+            ConcurrencyId = concurrencyId,
+            TracksProgress = progressIndex!=null,
+            ApiName = apiName,
+            Js = js,
+            ShowProgress = showProgress,
+            Every = every,
+            Cancels = cancels,
+            CollectsEventData = collects_event_data,
+            TriggerAfter = trigger_after,
+            TriggerOnlyOnSuccess = trigger_only_on_success,
+            TriggerMode = triggerMode,
+            Queue = queue,
+            ScrollToOutput = scrollToOutput,
+            ShowApi = showApi
+        };
+
+        this.Fns.Add(blockFn);
+        return (blockFn, this.Fns.Count - 1);
+    }
+
+    internal IEnumerable<Dictionary<string, object>> GetDependencies()
+    {
+        List<Dictionary<string, object>> result = [];
+        foreach (BlockFunction func in Fns)
+        {
+            result.Add(func.GetConfig());
         }
+
+        return result;
+    }
+
+    [IgnoreDataMember]
+    internal List<BlockFunction> Fns { get; set; } = [];
+
+    public Block this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+    private (IList, int? progressIndex, int? eventDataIndex) SpecialArgs(Func<Input,Task<Output>> fn)
+    {
+        //todo:Checks if function has special arguments Request or EventData (via annotation) or Progress (via default value).
+        return (null, null, null);
+    }
+
+    protected override Dictionary<string, object> GetProps()
+    {
+        Dictionary<string, object> result = base.GetProps();
+        if (result.ContainsKey("id"))
+        {
+            result.Remove("id");
+        }
+
+        if (result.ContainsKey("elem_classes"))
+        {
+            result.Remove("elem_classes");
+        }
+
+        return result;
+    }
+
+    public int IndexOf(Block item)
+    {
+        return _children.IndexOf(item);
+    }
+
+    public void Insert(int index, Block item)
+    {
+        _children.Insert(index, item);
+    }
+
+    public void RemoveAt(int index)
+    {
+       _children.RemoveAt(index);
     }
 }

--- a/Gradio.Net/Layouts/Column.cs
+++ b/Gradio.Net/Layouts/Column.cs
@@ -1,16 +1,12 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Column : Blocks
 {
-    public class Column : Blocks
-    {
-        internal Column() { }
-        internal int Scale { get;  set; }
-        internal int MinWidth { get;  set; }
-        internal ColumnVariant Variant { get;  set; }
-    }
+    internal Column() { }
+    internal int Scale { get;  set; }
+    internal int MinWidth { get;  set; }
+    internal ColumnVariant Variant { get;  set; }
 }

--- a/Gradio.Net/Layouts/Form.cs
+++ b/Gradio.Net/Layouts/Form.cs
@@ -1,36 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class Form : Blocks
 {
-    public class Form : Blocks
+    internal Form() { }
+    internal int MinWidth { get; set; }
+    internal int Scale { get; set; }
+
+    public override void Add(Block item)
     {
-        internal Form() { }
-        internal int MinWidth { get; set; }
-        internal int Scale { get; set; }
-
-        public override void Add(Block item)
+        FormComponent? formComponet = item as FormComponent;
+        if (this.ParentBlocks is Row row)
         {
-            var formComponet = item as FormComponent;
-            if (this.ParentBlocks is Row row)
-            {
-                var scale = formComponet.Scale;
-                var minWidth = formComponet.MinWidth;
-                this.Scale += scale.HasValue ? scale.Value : 1;
-                this.MinWidth += minWidth.HasValue ? minWidth.Value : 0;
-            }
-            else if (this.ParentBlocks is Blocks blocks && blocks.FillHeight.HasValue && blocks.FillHeight.Value)
-            {
-                var scale = formComponet.Scale;
-                this.Scale += scale.HasValue ? scale.Value : 1;
-            }
-
-            base.Add(item);
+            int? scale = formComponet.Scale;
+            int? minWidth = formComponet.MinWidth;
+            this.Scale += scale.HasValue ? scale.Value : 1;
+            this.MinWidth += minWidth.HasValue ? minWidth.Value : 0;
+        }
+        else if (this.ParentBlocks is Blocks blocks && blocks.FillHeight.HasValue && blocks.FillHeight.Value)
+        {
+            int? scale = formComponet.Scale;
+            this.Scale += scale.HasValue ? scale.Value : 1;
         }
 
+        base.Add(item);
     }
+
 }

--- a/Gradio.Net/Layouts/Group.cs
+++ b/Gradio.Net/Layouts/Group.cs
@@ -1,13 +1,6 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public class Group : Blocks
 {
-    public class Group : Blocks
-    {
-        internal Group() { }
-    }
+    internal Group() { }
 }

--- a/Gradio.Net/Layouts/Row.cs
+++ b/Gradio.Net/Layouts/Row.cs
@@ -1,15 +1,11 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Row : Blocks
 {
-    public class Row : Blocks
-    {
-        internal Row() { }
-        internal RowVariant Variant { get;  set; }
-        internal bool EqualHeight { get; set; } = true;
-    }
+    internal Row() { }
+    internal RowVariant Variant { get;  set; }
+    internal bool EqualHeight { get; set; } = true;
 }

--- a/Gradio.Net/Layouts/Tab.cs
+++ b/Gradio.Net/Layouts/Tab.cs
@@ -1,20 +1,13 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public class Tab : Blocks
 {
-    public class Tab : Blocks
+    internal Tab() { }
+    internal string Label { get;  set; }
+    internal string ComponentId { get;  set; }
+    protected override string GetTypeName()
     {
-        internal Tab() { }
-        internal string Label { get;  set; }
-        internal string ComponentId { get;  set; }
-        protected override string GetTypeName()
-        {
-            return "tabitem";  
-        }
-
+        return "tabitem";  
     }
+
 }

--- a/Gradio.Net/Layouts/Tabs.cs
+++ b/Gradio.Net/Layouts/Tabs.cs
@@ -1,13 +1,6 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public class Tabs : Blocks
 {
-    public class Tabs : Blocks
-    {
-        internal Tabs() { }
-    }
+    internal Tabs() { }
 }

--- a/Gradio.Net/Models/ChatMessage.cs
+++ b/Gradio.Net/Models/ChatMessage.cs
@@ -1,32 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class ChatMessage
 {
-    public class ChatMessage
+    public string FilePath { get; set; }
+    public string AltText { get; set; }
+    public string TextMessage { get; set; }
+}
+
+public class ChatbotMessagePair
+{
+    public ChatbotMessagePair(ChatMessage message, ChatMessage botMessage)
     {
-        public string FilePath { get; set; }
-        public string AltText { get; set; }
-        public string TextMessage { get; set; }
+        HumanMessage=message;
+        AiMessage=botMessage;
+    }
+    public ChatbotMessagePair(string message, string botMessage)
+    {
+        HumanMessage = new ChatMessage { TextMessage = message };
+        AiMessage = new ChatMessage { TextMessage = botMessage };
     }
 
-    public class ChatbotMessagePair
-    {
-        public ChatbotMessagePair(ChatMessage message, ChatMessage botMessage)
-        {
-            HumanMessage=message;
-            AiMessage=botMessage;
-        }
-        public ChatbotMessagePair(string message, string botMessage)
-        {
-            HumanMessage = new ChatMessage { TextMessage = message };
-            AiMessage = new ChatMessage { TextMessage = botMessage };
-        }
-
-        public ChatMessage HumanMessage { get; set; }
-        public ChatMessage AiMessage { get; set; }
-    }
+    public ChatMessage HumanMessage { get; set; }
+    public ChatMessage AiMessage { get; set; }
 }

--- a/Gradio.Net/Models/ChatbotData.cs
+++ b/Gradio.Net/Models/ChatbotData.cs
@@ -1,17 +1,7 @@
-﻿using Gradio.Net.Models;
-using Microsoft.AspNetCore.Components.Endpoints;
-using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class DropdownData
 {
-    public class DropdownData
-    {
-        public string Text { get; set; }
-        public string Value { get; set; }
-    }
+    public string Text { get; set; }
+    public string Value { get; set; }
 }

--- a/Gradio.Net/Models/DropdownData.cs
+++ b/Gradio.Net/Models/DropdownData.cs
@@ -1,16 +1,6 @@
-﻿using Gradio.Net.Models;
-using Microsoft.AspNetCore.Components.Endpoints;
-using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal class ChatbotData
 {
-    internal class ChatbotData
-    {
-        public List<string[]> Root { get; set; } 
-    }
+    public List<string[]> Root { get; set; } 
 }

--- a/Gradio.Net/Models/Event.cs
+++ b/Gradio.Net/Models/Event.cs
@@ -1,25 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+using System;
+
+internal class Event
 {
-    using Microsoft.AspNetCore.Http;
-    using System;
+    internal string RootUrl { get; set; }
+    internal string Id { get; } = Guid.NewGuid().ToString("N").ToLowerInvariant();
+    internal string SessionHash { get; set; }
+    internal int FnIndex { get; set; }
+    internal string Username { get; set; }
+    internal string ConcurrencyId { get; set; }
+    internal PredictBodyIn Data { get; set; }
+    internal bool ProgressPending { get; set; }
+    internal bool Alive { get; set; } = true;
 
-    internal class Event
-    {
-        internal string RootUrl { get; set; }
-        internal string Id { get; } = Guid.NewGuid().ToString("N").ToLowerInvariant();
-        internal string SessionHash { get; set; }
-        internal int FnIndex { get; set; }
-        internal string Username { get; set; }
-        internal string ConcurrencyId { get; set; }
-        internal PredictBodyIn Data { get; set; }
-        internal bool ProgressPending { get; set; }
-        internal bool Alive { get; set; } = true;
-
-    }
 }

--- a/Gradio.Net/Models/EventResult.cs
+++ b/Gradio.Net/Models/EventResult.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal class EventResult
 {
-    internal class EventResult
-    {
-        public IAsyncEnumerable<Output> StreamingOutputTask { get; internal set; }
-        internal BlockFunction BlockFunction { get;  set; }
-        internal Input Input { get;  set; }
-        internal Event Event { get; set; }
-        internal Task<Output> OutputTask { get; set; }
-    }
+    public IAsyncEnumerable<Output> StreamingOutputTask { get; internal set; }
+    internal BlockFunction BlockFunction { get;  set; }
+    internal Input Input { get;  set; }
+    internal Event Event { get; set; }
+    internal Task<Output> OutputTask { get; set; }
 }

--- a/Gradio.Net/Models/FileData.cs
+++ b/Gradio.Net/Models/FileData.cs
@@ -1,21 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class FileData
 {
-    public class FileData
-    {
-        public string Path { get; set; }
-        public string Name { get; set; } // filename
-        public string Data { get; set; } // base64 encoded data
-        public int? Size { get; set; } // size in bytes
-        public bool? IsFile { get; set; } // whether the data corresponds to a file or base64 encoded data
-        public string OrigName { get; set; } // original filename
-        public string MimeType { get; set; }
-        public bool? IsStream { get; set; }
-        public string Url { get; set; }
-    }
+    public string Path { get; set; }
+    public string Name { get; set; } // filename
+    public string Data { get; set; } // base64 encoded data
+    public int? Size { get; set; } // size in bytes
+    public bool? IsFile { get; set; } // whether the data corresponds to a file or base64 encoded data
+    public string OrigName { get; set; } // original filename
+    public string MimeType { get; set; }
+    public bool? IsStream { get; set; }
+    public string Url { get; set; }
 }

--- a/Gradio.Net/Models/FileMessage.cs
+++ b/Gradio.Net/Models/FileMessage.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal class FileMessage
 {
-    internal class FileMessage
-    {
-        public FileData File { get; set; }
-        public string AltText { get; set; } = null;
-    }
+    public FileData File { get; set; }
+    public string AltText { get; set; } = null;
 }

--- a/Gradio.Net/Models/Input.cs
+++ b/Gradio.Net/Models/Input.cs
@@ -1,16 +1,10 @@
 ﻿using Gradio.Net.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class Input
 {
-    public class Input
-    {
-        public object[] Data { get; set; }
+    public object[] Data { get; set; }
 
-        public Progress Progress { get; set; }
-    }
+    public Progress Progress { get; set; }
 }

--- a/Gradio.Net/Models/LabelData.cs
+++ b/Gradio.Net/Models/LabelData.cs
@@ -1,20 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.Models;
 
-namespace Gradio.Net.Models
+public class LabelData
 {
-    public class LabelData
+    public string Label { get; set; }
+    public IEnumerable<LabelConfidence> Confidences { get; set; }
+
+    public class LabelConfidence
     {
         public string Label { get; set; }
-        public IEnumerable<LabelConfidence> Confidences { get; set; }
-
-        public class LabelConfidence
-        {
-            public string Label { get; set; }
-            public decimal Confidence { get; set; }
-        }
+        public decimal Confidence { get; set; }
     }
 }

--- a/Gradio.Net/Models/MultimodalData.cs
+++ b/Gradio.Net/Models/MultimodalData.cs
@@ -1,14 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class MultimodalData
 {
-    public class MultimodalData
-    {
-        public string Text { get; set; }
-        public IEnumerable<FileData> Files { get; set; }
-    }
+    public string Text { get; set; }
+    public IEnumerable<FileData> Files { get; set; }
 }

--- a/Gradio.Net/Models/Output.cs
+++ b/Gradio.Net/Models/Output.cs
@@ -1,22 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public class Output
 {
-    public class Output
-    {
-        public object[] Data { get; set; }
+    public object[] Data { get; set; }
+}
+
+internal class ErrorOutput : Output
+{ 
+    public ErrorOutput(Exception ex) {
+        Exception = ex;
     }
 
-    internal class ErrorOutput : Output
-    { 
-        public ErrorOutput(Exception ex) {
-            Exception = ex;
-        }
-
-        public Exception Exception { get; private set; }
-    }
+    public Exception Exception { get; private set; }
 }

--- a/Gradio.Net/Models/PredictBodyIn.cs
+++ b/Gradio.Net/Models/PredictBodyIn.cs
@@ -1,28 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class PredictBodyIn
 {
-    internal class PredictBodyIn
-    {
-        [JsonPropertyName("session_hash")]
-        public string SessionHash { get; set; }
-        [JsonPropertyName("event_id")]
-        public string? EventId { get; set; }
-        [JsonPropertyName("data")]
-        public object[] Data { get; set; }
-        [JsonPropertyName("fn_index")]
-        public int FnIndex { get; set; }
-        [JsonPropertyName("trigger_id")]
-        public int? TriggerId { get; set; }
-        [JsonPropertyName("simple_format")]
-        public bool SimpleFormat { get; set; }
-        [JsonPropertyName("batched")]
-        public bool Batched { get; set; }
-    }
-
+    [JsonPropertyName("session_hash")]
+    public string SessionHash { get; set; }
+    [JsonPropertyName("event_id")]
+    public string? EventId { get; set; }
+    [JsonPropertyName("data")]
+    public object[] Data { get; set; }
+    [JsonPropertyName("fn_index")]
+    public int FnIndex { get; set; }
+    [JsonPropertyName("trigger_id")]
+    public int? TriggerId { get; set; }
+    [JsonPropertyName("simple_format")]
+    public bool SimpleFormat { get; set; }
+    [JsonPropertyName("batched")]
+    public bool Batched { get; set; }
 }

--- a/Gradio.Net/Models/QueueJoinOut.cs
+++ b/Gradio.Net/Models/QueueJoinOut.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
+﻿using System.Text.Json.Serialization;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public class QueueJoinOut
 {
-    public class QueueJoinOut
-    {
-        [JsonPropertyName("event_id")]
-        public string? EventId { get; set; }
-    }
+    [JsonPropertyName("event_id")]
+    public string? EventId { get; set; }
 }

--- a/Gradio.Net/Models/SSEMessage.cs
+++ b/Gradio.Net/Models/SSEMessage.cs
@@ -1,123 +1,113 @@
 ﻿using Gradio.Net.Enums;
 using Gradio.Net.Helpers;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
-namespace Gradio.Net.Models
+namespace Gradio.Net.Models;
+
+[JsonDerivedType(typeof(ProcessCompletedMessage))]
+[JsonDerivedType(typeof(UnexpectedErrorMessage))]
+[JsonDerivedType(typeof(CloseStreamMessage))]
+[JsonDerivedType(typeof(HeartbeatMessage))]
+[JsonDerivedType(typeof(ProgressMessage))]
+[JsonDerivedType(typeof(ProcessGeneratingMessage))]
+[JsonDerivedType(typeof(ProcessStartsMessage))]
+
+public abstract class SSEMessage
 {
-    [JsonDerivedType(typeof(ProcessCompletedMessage))]
-    [JsonDerivedType(typeof(UnexpectedErrorMessage))]
-    [JsonDerivedType(typeof(CloseStreamMessage))]
-    [JsonDerivedType(typeof(HeartbeatMessage))]
-    [JsonDerivedType(typeof(ProgressMessage))]
-    [JsonDerivedType(typeof(ProcessGeneratingMessage))]
-    [JsonDerivedType(typeof(ProcessStartsMessage))]
-    
-    public abstract class SSEMessage
+    public SSEMessage(SSEMessageType msg, string message, bool? success)
     {
-        public SSEMessage(SSEMessageType msg, string message, bool? success)
-        {
-            Msg = msg;
-            Message = message;
-            Success = success;
-        }
-        [JsonConverter(typeof(SSEMessageTypeJsonConverter))]
-        public SSEMessageType Msg { get; set; }
-        public string Message { get; set; }
-        public bool? Success { get; set; }
+        Msg = msg;
+        Message = message;
+        Success = success;
+    }
+    [JsonConverter(typeof(SSEMessageTypeJsonConverter))]
+    public SSEMessageType Msg { get; set; }
+    public string Message { get; set; }
+    public bool? Success { get; set; }
 
-        internal string ProcessMsg()
-        {
-            return $"data: {JsonUtils.Serialize(this)}\n\n";
-        }
+    internal string ProcessMsg()
+    {
+        return $"data: {JsonUtils.Serialize(this)}\n\n";
+    }
+}
+
+public class ProcessStartsMessage : SSEMessage
+{
+    public ProcessStartsMessage(string eventId)
+        : base(SSEMessageType.ProcessStarts, null, null) {
+        EventId = eventId; 
+    }
+    public string EventId { get; set; }
+    public decimal? Eta { get; set; }
+}
+
+public class UnexpectedErrorMessage : SSEMessage
+{
+    public UnexpectedErrorMessage(string message)
+        : base(SSEMessageType.UnexpectedError, message, false) { }
+}
+
+public class CloseStreamMessage : SSEMessage
+{
+    public CloseStreamMessage()
+        : base(SSEMessageType.CloseStream, null, null) { }
+}
+
+public class HeartbeatMessage : SSEMessage
+{
+    public HeartbeatMessage()
+        : base(SSEMessageType.Heartbeat, null, null) { }
+}
+
+public class ProcessCompletedMessage : SSEMessage
+{
+    public ProcessCompletedMessage(string eventId, Dictionary<string, object> output)
+        : base(SSEMessageType.ProcessCompleted, null, true) {
+        this.EventId = eventId;
+        this.Output = output;
     }
 
-    public class ProcessStartsMessage : SSEMessage
+    public string EventId { get; set; }
+    public Dictionary<string, object> Output { get; set; }
+}
+
+public class ProgressMessage : SSEMessage
+{
+    public ProgressMessage(string eventId, Progress progress)
+        : base(SSEMessageType.Progress, null, null)
     {
-        public ProcessStartsMessage(string eventId)
-            : base(SSEMessageType.ProcessStarts, null, null) {
-            EventId = eventId; 
-        }
-        public string EventId { get; set; }
-        public decimal? Eta { get; set; }
+        ProgressData = new List<ProgressUnit> {
+            new() {
+                Index =progress.Index,
+                Desc = progress.Desc,
+                Length = progress.Length,
+                Unit = progress.Unit
+            }
+        };
     }
 
-    public class UnexpectedErrorMessage : SSEMessage
+    public IEnumerable<ProgressUnit> ProgressData { get; set; }
+
+    public class ProgressUnit
     {
-        public UnexpectedErrorMessage(string message)
-            : base(SSEMessageType.UnexpectedError, message, false) { }
+        public int Index { get; set; }
+        public int Length { get; set; }
+        public string Unit { get; set; }
+        public decimal? Progress { get; set; }
+        public string Desc { get; set; }
+    }
+}
+
+public class ProcessGeneratingMessage : SSEMessage
+{
+    public ProcessGeneratingMessage(string eventId, Dictionary<string, object> output)
+        : base(SSEMessageType.ProcessGenerating, null, true)
+    {
+        this.EventId = eventId;
+        this.Output = output;
     }
 
-    public class CloseStreamMessage : SSEMessage
-    {
-        public CloseStreamMessage()
-            : base(SSEMessageType.CloseStream, null, null) { }
-    }
-
-    public class HeartbeatMessage : SSEMessage
-    {
-        public HeartbeatMessage()
-            : base(SSEMessageType.Heartbeat, null, null) { }
-    }
-
-    public class ProcessCompletedMessage : SSEMessage
-    {
-        public ProcessCompletedMessage(string eventId, Dictionary<string, object> output)
-            : base(SSEMessageType.ProcessCompleted, null, true) {
-            this.EventId = eventId;
-            this.Output = output;
-        }
-
-        public string EventId { get; set; }
-        public Dictionary<string, object> Output { get; set; }
-    }
-
-    public class ProgressMessage : SSEMessage
-    {
-        public ProgressMessage(string eventId, Progress progress)
-            : base(SSEMessageType.Progress, null, null)
-        {
-            ProgressData = new List<ProgressUnit> {
-                new ProgressUnit
-                {
-                    Index =progress.Index,
-                    Desc = progress.Desc,
-                    Length = progress.Length,
-                    Unit = progress.Unit
-                }
-            };
-        }
-
-        public IEnumerable<ProgressUnit> ProgressData { get; set; }
-
-        public class ProgressUnit
-        {
-            public int Index { get; set; }
-            public int Length { get; set; }
-            public string Unit { get; set; }
-            public decimal? Progress { get; set; }
-            public string Desc { get; set; }
-        }
-    }
-
-    public class ProcessGeneratingMessage : SSEMessage
-    {
-        public ProcessGeneratingMessage(string eventId, Dictionary<string, object> output)
-            : base(SSEMessageType.ProcessGenerating, null, true)
-        {
-            this.EventId = eventId;
-            this.Output = output;
-        }
-
-        public string EventId { get; set; }
-        public Dictionary<string, object> Output { get; set; }
-        public bool IsGenerating { get; set; } = true;
-    }
+    public string EventId { get; set; }
+    public Dictionary<string, object> Output { get; set; }
+    public bool IsGenerating { get; set; } = true;
 }

--- a/Gradio.Net/StaticFileProvider.cs
+++ b/Gradio.Net/StaticFileProvider.cs
@@ -4,68 +4,64 @@ using Microsoft.Extensions.Primitives;
 using System.Reflection;
 using System.Text;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class StaticFileProvider : IFileProvider
 {
-    internal class StaticFileProvider : IFileProvider
-    {
-        private static readonly char[] _pathSeparators = new[]
-            {Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar};
-        private readonly string _rootPath;
-        private readonly Assembly? _assembly;
-        private readonly DateTimeOffset _lastModified;
-        private readonly string? _baseNamespace;
+    private static readonly char[] _pathSeparators = [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar];
+    private readonly string _rootPath;
+    private readonly Assembly? _assembly;
+    private readonly DateTimeOffset _lastModified;
+    private readonly string? _baseNamespace;
 
-        internal StaticFileProvider(string rootPath) { 
-            this._rootPath = rootPath;
-            this._assembly = Assembly.GetAssembly(typeof(StaticFileProvider));
-            this._lastModified= DateTimeOffset.UtcNow;
-            this._baseNamespace = typeof(StaticFileProvider).Namespace;
-        }
-
-        public IFileInfo GetFileInfo(string subpath)
-        {            
-            subpath =_rootPath+"/"+ subpath.TrimStart(_pathSeparators);
-
-            if (Path.IsPathRooted(subpath))
-            {
-                return new NotFoundFileInfo(subpath);
-            }
-
-            if (string.IsNullOrEmpty(subpath))
-            {
-                return new NotFoundFileInfo(subpath);
-            }
-
-            var builder = new StringBuilder(_baseNamespace.Length + subpath.Length);
-            builder.Append(_baseNamespace);
-
-            if (subpath.StartsWith("/", StringComparison.Ordinal))
-            {
-                subpath = subpath.Substring(1, subpath.Length - 1);
-            }
-
-            builder.Append("."+subpath.Replace("/","."));
-
-            var resourcePath = builder.ToString();
-            
-            var name = Path.GetFileName(subpath);
-            if (_assembly.GetManifestResourceInfo(resourcePath) == null)
-            {
-                return new NotFoundFileInfo(name);
-            }
-
-            return new EmbeddedResourceFileInfo(_assembly, resourcePath, name, _lastModified); ;
-        }
-        public IDirectoryContents GetDirectoryContents(string subpath)
-        {
-            return null;
-        }
-          
-        public IChangeToken Watch(string filter)
-        {
-            return null;
-        }
+    internal StaticFileProvider(string rootPath) { 
+        this._rootPath = rootPath;
+        this._assembly = Assembly.GetAssembly(typeof(StaticFileProvider));
+        this._lastModified= DateTimeOffset.UtcNow;
+        this._baseNamespace = typeof(StaticFileProvider).Namespace;
     }
 
+    public IFileInfo GetFileInfo(string subpath)
+    {            
+        subpath =_rootPath+"/"+ subpath.TrimStart(_pathSeparators);
 
+        if (Path.IsPathRooted(subpath))
+        {
+            return new NotFoundFileInfo(subpath);
+        }
+
+        if (string.IsNullOrEmpty(subpath))
+        {
+            return new NotFoundFileInfo(subpath);
+        }
+
+        StringBuilder builder = new(_baseNamespace.Length + subpath.Length);
+        builder.Append(_baseNamespace);
+
+        if (subpath.StartsWith("/", StringComparison.Ordinal))
+        {
+            subpath = subpath.Substring(1, subpath.Length - 1);
+        }
+
+        builder.Append("."+subpath.Replace("/","."));
+
+        string resourcePath = builder.ToString();
+
+        string name = Path.GetFileName(subpath);
+        if (_assembly.GetManifestResourceInfo(resourcePath) == null)
+        {
+            return new NotFoundFileInfo(name);
+        }
+
+        return new EmbeddedResourceFileInfo(_assembly, resourcePath, name, _lastModified); ;
+    }
+    public IDirectoryContents GetDirectoryContents(string subpath)
+    {
+        return null;
+    }
+      
+    public IChangeToken Watch(string filter)
+    {
+        return null;
+    }
 }

--- a/Gradio.Net/Utils/ClientUtils.cs
+++ b/Gradio.Net/Utils/ClientUtils.cs
@@ -1,30 +1,23 @@
 ﻿using Microsoft.AspNetCore.StaticFiles;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal static class ClientUtils
 {
-    internal static class ClientUtils
+    internal static string GetMimeType(string filePath)
     {
-        internal static string GetMimeType(string filePath)
+        const string DefaultContentType = "application/octet-stream";
+        FileExtensionContentTypeProvider provider = new();
+        if (!provider.TryGetContentType(filePath, out string contentType))
         {
-            const string DefaultContentType = "application/octet-stream";
-            var provider = new FileExtensionContentTypeProvider();
-            if (!provider.TryGetContentType(filePath, out string contentType))
-            {
-                contentType = DefaultContentType;
-            }
-
-            return contentType;
+            contentType = DefaultContentType;
         }
 
-        internal static bool IsUrl(string str)
-        {
-            return str.StartsWith("http://", StringComparison.InvariantCultureIgnoreCase) || str.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase);
-        }
+        return contentType;
+    }
+
+    internal static bool IsUrl(string str)
+    {
+        return str.StartsWith("http://", StringComparison.InvariantCultureIgnoreCase) || str.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase);
     }
 }

--- a/Gradio.Net/Utils/GradioUtils.cs
+++ b/Gradio.Net/Utils/GradioUtils.cs
@@ -1,17 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+internal static class GradioUtils
 {
-    internal static class GradioUtils
+    internal static string GetSpace()
     {
-        internal static string GetSpace()
-        {
-            //todo
-            return null;
-        }
+        //todo
+        return null;
     }
 }

--- a/Gradio.Net/Utils/HttpRequestExtensions.cs
+++ b/Gradio.Net/Utils/HttpRequestExtensions.cs
@@ -1,17 +1,11 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal static class HttpRequestExtensions
 {
-    internal static class HttpRequestExtensions
+    public static string GetRootUrl(this HttpRequest httpRequest)
     {
-        public static string GetRootUrl(this HttpRequest httpRequest)
-        {
-            return $"{httpRequest.Scheme}://{httpRequest.Host}";
-        }
+        return $"{httpRequest.Scheme}://{httpRequest.Host}";
     }
 }

--- a/Gradio.Net/Utils/JsonUtils.cs
+++ b/Gradio.Net/Utils/JsonUtils.cs
@@ -1,31 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using System.Text.Json;
-using System.Threading.Tasks;
-using Gradio.Net.Models;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal static class JsonUtils
 {
-    internal static class JsonUtils
+    private static JsonSerializerOptions _serializeOptions = new()
     {
-        private static JsonSerializerOptions _serializeOptions = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-            WriteIndented = false,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
 
-        internal static T Deserialize<T>(string str)
-        {
-            return JsonSerializer.Deserialize<T>(str, _serializeOptions);
-        }
+    internal static T Deserialize<T>(string str)
+    {
+        return JsonSerializer.Deserialize<T>(str, _serializeOptions);
+    }
 
-        internal static string Serialize<T>(T obj)
-        {
-            return JsonSerializer.Serialize(obj, _serializeOptions);
-        }
+    internal static string Serialize<T>(T obj)
+    {
+        return JsonSerializer.Serialize(obj, _serializeOptions);
     }
 }

--- a/Gradio.Net/Utils/SSEMessageTypeJsonConverter.cs
+++ b/Gradio.Net/Utils/SSEMessageTypeJsonConverter.cs
@@ -1,25 +1,18 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+internal class SSEMessageTypeJsonConverter : JsonConverter<SSEMessageType>
 {
-    internal class SSEMessageTypeJsonConverter : JsonConverter<SSEMessageType>
+    public override SSEMessageType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        public override SSEMessageType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            throw new NotImplementedException();
-        }
+        throw new NotImplementedException();
+    }
 
-        public override void Write(Utf8JsonWriter writer, SSEMessageType value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value.ToString().ToSnakeCase().ToLowerInvariant());
-        }
+    public override void Write(Utf8JsonWriter writer, SSEMessageType value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString().ToSnakeCase().ToLowerInvariant());
     }
 }

--- a/Gradio.Net/Utils/StringExtensions.cs
+++ b/Gradio.Net/Utils/StringExtensions.cs
@@ -1,46 +1,39 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿namespace Gradio.Net;
+
 using System.Text;
-using System.Threading.Tasks;
 
-namespace Gradio.Net
+internal static class StringExtensions
 {
-    using System.Text;
-
-    internal static class StringExtensions
+    internal static string ToSnakeCase(this string text)
     {
-        internal static string ToSnakeCase(this string text)
+        if (text == null)
         {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
-            if (text.Length < 2)
-            {
-                return text.ToLowerInvariant();
-            }
-
-            var sb = new StringBuilder();
-            sb.Append(char.ToLowerInvariant(text[0]));
-
-            for (int i = 1; i < text.Length; ++i)
-            {
-                char c = text[i];
-
-                if (char.IsUpper(c))
-                {
-                    sb.Append('_');
-                    sb.Append(char.ToLowerInvariant(c));
-                }
-                else
-                {
-                    sb.Append(c);
-                }
-            }
-
-            return sb.ToString();
+            throw new ArgumentNullException(nameof(text));
         }
+
+        if (text.Length < 2)
+        {
+            return text.ToLowerInvariant();
+        }
+
+        StringBuilder sb = new();
+        sb.Append(char.ToLowerInvariant(text[0]));
+
+        for (int i = 1; i < text.Length; ++i)
+        {
+            char c = text[i];
+
+            if (char.IsUpper(c))
+            {
+                sb.Append('_');
+                sb.Append(char.ToLowerInvariant(c));
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
     }
 }

--- a/Gradio.Net/_gr/gr_Accordion.cs
+++ b/Gradio.Net/_gr/gr_Accordion.cs
@@ -1,36 +1,28 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Reflection.Emit;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Accordion Accordion(
+        string label=null,        
+        bool open = true,        
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true
+    )
     {
-        public static Accordion Accordion(
-            string label=null,        
-            bool open = true,        
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true
-        )
-        {
-            var block = new Accordion();
+        Accordion block = [];
 
-            block.Label = label;
-            block.Open = open;
+        block.Label = label;
+        block.Open = open;
 
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
 
-            Context.SetCurrentBlocks(block);
+        Context.SetCurrentBlocks(block);
 
-            return block;
-        }
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Blocks.cs
+++ b/Gradio.Net/_gr/gr_Blocks.cs
@@ -1,35 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Blocks Blocks(string theme = "default",
+    bool analyticsEnabled=true,
+    string mode = "blocks",
+    string title = "Gradio.Net",
+    string css = null,
+    string js = null,
+    string head = null,
+    bool fillHeight = false,
+    Tuple<int,int> deleteCache=null)
     {
-        public static Blocks Blocks(string theme = "default",
-        bool analyticsEnabled=true,
-        string mode = "blocks",
-        string title = "Gradio.Net",
-        string css = null,
-        string js = null,
-        string head = null,
-        bool fillHeight = false,
-        Tuple<int,int> deleteCache=null)
-        { 
-            var blocks = new Blocks() {
-                Theme= theme,
-                AnalyticsEnabled= analyticsEnabled,
-                Mode= mode,
-                Title = title,
-                Css= css,
-                Js= js,
-                Head= head,
-                FillHeight= fillHeight,
-                DeleteCache= deleteCache,
-            };
-            Context.SetCurrentBlocks(blocks);
-            return blocks;
-        }
+        Blocks blocks = new() {
+            Theme= theme,
+            AnalyticsEnabled= analyticsEnabled,
+            Mode= mode,
+            Title = title,
+            Css= css,
+            Js= js,
+            Head= head,
+            FillHeight= fillHeight,
+            DeleteCache= deleteCache,
+        };
+        Context.SetCurrentBlocks(blocks);
+        return blocks;
     }
 }

--- a/Gradio.Net/_gr/gr_Button.cs
+++ b/Gradio.Net/_gr/gr_Button.cs
@@ -1,49 +1,41 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Button Button(
+        string value = "Run",
+        decimal? every = null,
+        ButtonVariant variant = ButtonVariant.Secondary,
+        ButtonSize? size = null,
+       string icon = null,
+        string link = null,
+        bool visible = true,
+        bool interactive = true,
+        string elemId = null,
+       IEnumerable<string> elemClasses = null,
+       bool render = true,
+        int? scale = null,
+       int? minWidth = null)
     {
-        public static Button Button(
-            string value = "Run",
-            decimal? every = null,
-            ButtonVariant variant = ButtonVariant.Secondary,
-            ButtonSize? size = null,
-           string icon = null,
-            string link = null,
-            bool visible = true,
-            bool interactive = true,
-            string elemId = null,
-           IEnumerable<string> elemClasses = null,
-           bool render = true,
-            int? scale = null,
-           int? minWidth = null)
+        Button block = new()
         {
-            var block = new Button()
-            {
-                Value = value,
-                Every = every,
-                Variant = variant,
-                Size = size,
-                Icon = icon,
-                Link = link,
-                Visible = visible,
-                Interactive = interactive,
-                ElemId = elemId,
-                ElemClasses = elemClasses,
-                Render = render,
-                Scale = scale,
-                MinWidth = minWidth
-            };
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+            Value = value,
+            Every = every,
+            Variant = variant,
+            Size = size,
+            Icon = icon,
+            Link = link,
+            Visible = visible,
+            Interactive = interactive,
+            ElemId = elemId,
+            ElemClasses = elemClasses,
+            Render = render,
+            Scale = scale,
+            MinWidth = minWidth
+        };
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Chatbot .cs
+++ b/Gradio.Net/_gr/gr_Chatbot .cs
@@ -1,76 +1,63 @@
-﻿using Gradio.Net.Enums;
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using System.Xml.Linq;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Chatbot  Chatbot(
+        IEnumerable<object> value = null,
+        string label = null,
+        decimal? every = null,
+        bool? showLabel = null,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true,
+        string key = null,
+        int? height = null,
+        IEnumerable<Dictionary<string, object>> latexDelimiters = null,
+        bool rtl = false,
+        bool? showShareButton = null,
+        bool showCopyButton = false,
+        Tuple<string, string> avatarImages = null,
+        bool sanitizeHtml = true,
+        bool renderMarkdown = true,
+        bool bubbleFullWidth = true,
+        bool lineBreaks = true,
+        bool likeable = false,
+        string layout = null,
+        string placeholder = null)
     {
-        public static Chatbot  Chatbot(
-            IEnumerable<object> value = null,
-            string label = null,
-            decimal? every = null,
-            bool? showLabel = null,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true,
-            string key = null,
-            int? height = null,
-            IEnumerable<Dictionary<string, object>> latexDelimiters = null,
-            bool rtl = false,
-            bool? showShareButton = null,
-            bool showCopyButton = false,
-            Tuple<string, string> avatarImages = null,
-            bool sanitizeHtml = true,
-            bool renderMarkdown = true,
-            bool bubbleFullWidth = true,
-            bool lineBreaks = true,
-            bool likeable = false,
-            string layout = null,
-            string placeholder = null)
-        {
-            var block = new Chatbot();
-            block.Value = value;
-            block.Label = label;
-            block.Every = every;
-            block.ShowLabel = showLabel;
-            block.Container = container;
-            block.Scale = scale;
-            block.MinWidth = minWidth;
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
-            block.Key = key;
-            block.Height = height;
-            block.LatexDelimiters = latexDelimiters;
-            block.Rtl = rtl;
-            block.ShowShareButton = showShareButton ?? (GradioUtils.GetSpace() != null);
-            block.RenderMarkdown = renderMarkdown;
-            block.ShowCopyButton = showCopyButton;
-            block.AvatarImages = avatarImages;
-            block.SanitizeHtml = sanitizeHtml;
-            block.RenderMarkdown = renderMarkdown;
-            block.BubbleFullWidth = bubbleFullWidth;
-            block.LineBreaks = lineBreaks;
-            block.Likeable = likeable;
-            block.Layout = layout;
-            block.Placeholder = placeholder;
+        Chatbot block = new();
+        block.Value = value;
+        block.Label = label;
+        block.Every = every;
+        block.ShowLabel = showLabel;
+        block.Container = container;
+        block.Scale = scale;
+        block.MinWidth = minWidth;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
+        block.Key = key;
+        block.Height = height;
+        block.LatexDelimiters = latexDelimiters;
+        block.Rtl = rtl;
+        block.ShowShareButton = showShareButton ?? (GradioUtils.GetSpace() != null);
+        block.RenderMarkdown = renderMarkdown;
+        block.ShowCopyButton = showCopyButton;
+        block.AvatarImages = avatarImages;
+        block.SanitizeHtml = sanitizeHtml;
+        block.RenderMarkdown = renderMarkdown;
+        block.BubbleFullWidth = bubbleFullWidth;
+        block.LineBreaks = lineBreaks;
+        block.Likeable = likeable;
+        block.Layout = layout;
+        block.Placeholder = placeholder;
 
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Checkbox.cs
+++ b/Gradio.Net/_gr/gr_Checkbox.cs
@@ -1,55 +1,42 @@
-﻿using Gradio.Net.Enums;
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using System.Xml.Linq;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Checkbox Checkbox(
+        bool value=false,
+        string label=null,
+        string info = null,
+        decimal? every= null,
+        bool? showLabel= null,
+        bool  container =true,
+       int? scale = null,
+       int minWidth =160,
+      bool?  interactive = null,
+       bool  visible=true,
+      string  elemId = null,
+      IEnumerable<string>  elemClasses = null,
+       bool  render=true,
+      string   key=null
+    )
     {
-        public static Checkbox Checkbox(
-            bool value=false,
-            string label=null,
-            string info = null,
-            decimal? every= null,
-            bool? showLabel= null,
-            bool  container =true,
-           int? scale = null,
-           int minWidth =160,
-          bool?  interactive = null,
-           bool  visible=true,
-          string  elemId = null,
-          IEnumerable<string>  elemClasses = null,
-           bool  render=true,
-          string   key=null
-        )
-        { 
-            var block = new Checkbox();
+        Checkbox block = new();
 
-            block.Label = label;
-            block.Info = info;
-            block.Every = every;
-            block.ShowLabel = showLabel;
-            block.Container = container;
-            block.Scale = scale;
-            block.MinWidth = minWidth;
-            block.Interactive = interactive;
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
-            block.Key = key;
-            block.Value = value;
-        
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        block.Label = label;
+        block.Info = info;
+        block.Every = every;
+        block.ShowLabel = showLabel;
+        block.Container = container;
+        block.Scale = scale;
+        block.MinWidth = minWidth;
+        block.Interactive = interactive;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
+        block.Key = key;
+        block.Value = value;
+    
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_CheckboxGroup.cs
+++ b/Gradio.Net/_gr/gr_CheckboxGroup.cs
@@ -1,56 +1,46 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using System.Xml.Linq;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static CheckboxGroup CheckboxGroup(
+        IEnumerable<string> choices = null,
+        object value = null,
+       CheckboxGroupType type = CheckboxGroupType.Value,
+       string label = null,
+       string info = null,                       
+        decimal? every = null,
+        bool? showLabel = null,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true
+    )
     {
-        public static CheckboxGroup CheckboxGroup(
-            IEnumerable<string> choices = null,
-            object value = null,
-           CheckboxGroupType type = CheckboxGroupType.Value,
-           string label = null,
-           string info = null,                       
-            decimal? every = null,
-            bool? showLabel = null,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true
-        )
-        { 
-            var block = new CheckboxGroup();
-            block.Choices = choices;
-            block.Type = type;
-            
-            block.Label = label;
-            block.Info = info;
-            block.Every = every;
-            block.ShowLabel = showLabel;
-            block.Container = container;
-            block.Scale = scale;
-            block.MinWidth = minWidth;
-            block.Interactive = interactive;
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
-            block.Value = value;
-            
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        CheckboxGroup block = new();
+        block.Choices = choices;
+        block.Type = type;
+        
+        block.Label = label;
+        block.Info = info;
+        block.Every = every;
+        block.ShowLabel = showLabel;
+        block.Container = container;
+        block.Scale = scale;
+        block.MinWidth = minWidth;
+        block.Interactive = interactive;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
+        block.Value = value;
+        
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Column.cs
+++ b/Gradio.Net/_gr/gr_Column.cs
@@ -1,37 +1,32 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Column Column(
+        int scale = 1,
+        int minWidth = 320,
+        ColumnVariant variant = ColumnVariant.Default,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true
+    )
     {
-        public static Column Column(
-            int scale = 1,
-            int minWidth = 320,
-            ColumnVariant variant = ColumnVariant.Default,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true
-        )
-        {
-            var block = new Column();
+        Column block = [];
 
-            block.Scale = scale;
-            block.MinWidth = minWidth;
-            block.Variant = variant;
+        block.Scale = scale;
+        block.MinWidth = minWidth;
+        block.Variant = variant;
 
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
 
-            Context.SetCurrentBlocks(block);
+        Context.SetCurrentBlocks(block);
 
-            return block;
-        }
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Dropdown.cs
+++ b/Gradio.Net/_gr/gr_Dropdown.cs
@@ -1,64 +1,54 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using System.Xml.Linq;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Dropdown Dropdown(
+        IEnumerable<string> choices = null,
+        object value = null,
+        DropdownType type = DropdownType.Value,
+        bool? multiselect = null,
+        bool allowCustomValue = false,
+        int? maxChoices = null,
+        bool filterable = true,
+        string label = null,
+        string info = null,
+        decimal? every = null,
+        bool? showLabel = null,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true
+    )
     {
-        public static Dropdown Dropdown(
-            IEnumerable<string> choices = null,
-            object value = null,
-            DropdownType type = DropdownType.Value,
-            bool? multiselect = null,
-            bool allowCustomValue = false,
-            int? maxChoices = null,
-            bool filterable = true,
-            string label = null,
-            string info = null,
-            decimal? every = null,
-            bool? showLabel = null,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true
-        )
-        { 
-            var block = new Dropdown();
-            block.Choices = choices;
-            block.Type = type;
-            block.Multiselect = multiselect;
-            block.MaxChoices = maxChoices;
-            block.AllowCustomValue = allowCustomValue;
-            block.Filterable = filterable;
-            
-            block.Label = label;
-            block.Info = info;
-            block.Every = every;
-            block.ShowLabel = showLabel;
-            block.Container = container;
-            block.Scale = scale;
-            block.MinWidth = minWidth;
-            block.Interactive = interactive;
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
-            block.Value = value;
-            
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        Dropdown block = new();
+        block.Choices = choices;
+        block.Type = type;
+        block.Multiselect = multiselect;
+        block.MaxChoices = maxChoices;
+        block.AllowCustomValue = allowCustomValue;
+        block.Filterable = filterable;
+        
+        block.Label = label;
+        block.Info = info;
+        block.Every = every;
+        block.ShowLabel = showLabel;
+        block.Container = container;
+        block.Scale = scale;
+        block.MinWidth = minWidth;
+        block.Interactive = interactive;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
+        block.Value = value;
+        
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Event.cs
+++ b/Gradio.Net/_gr/gr_Event.cs
@@ -1,11 +1,4 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace Gradio.Net;
 

--- a/Gradio.Net/_gr/gr_Group.cs
+++ b/Gradio.Net/_gr/gr_Group.cs
@@ -1,30 +1,23 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Group Group(            
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true
+    )
     {
-        public static Group Group(            
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true
-        )
-        {
-            var block = new Group();
+        Group block = [];
 
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
 
-            Context.SetCurrentBlocks(block);
+        Context.SetCurrentBlocks(block);
 
-            return block;
-        }
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_HTML.cs
+++ b/Gradio.Net/_gr/gr_HTML.cs
@@ -1,32 +1,25 @@
-﻿using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using System;
-using System.Collections.Generic;
-using System.Reflection.Emit;
-using System.Text;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static HTML HTML(string value="",
+    string label=null,
+    decimal? every=null,
+    bool showLabel=true,
+    bool visible  = true,
+    string elemId= null,
+    IEnumerable<string> elemClasses=null)
     {
-        public static HTML HTML(string value="",
-        string label=null,
-        decimal? every=null,
-        bool showLabel=true,
-        bool visible  = true,
-        string elemId= null,
-        IEnumerable<string> elemClasses=null)
-        {
-            var block = new HTML() {
-                Value= value,
-                Label= label,
-                Every= every,
-                ShowLabel= showLabel,
-                Visible= visible,
-                ElemId= elemId,
-               ElemClasses= elemClasses,
-            };
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        HTML block = new() {
+            Value= value,
+            Label= label,
+            Every= every,
+            ShowLabel= showLabel,
+            Visible= visible,
+            ElemId= elemId,
+           ElemClasses= elemClasses,
+        };
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Helpers.cs
+++ b/Gradio.Net/_gr/gr_Helpers.cs
@@ -1,14 +1,13 @@
 ﻿
 using Gradio.Net.Helpers;
 
-namespace Gradio.Net
-{
-    public static partial class gr
-    {
+namespace Gradio.Net;
 
-        public static Progress Progress(int total)
-        { 
-            return new Progress(total);
-        }
+public static partial class gr
+{
+
+    public static Progress Progress(int total)
+    { 
+        return new Progress(total);
     }
 }

--- a/Gradio.Net/_gr/gr_Image.cs
+++ b/Gradio.Net/_gr/gr_Image.cs
@@ -1,77 +1,68 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Image Image(
+        string value = null,
+        ImageFormat format = ImageFormat.Webp,
+        int? height = null,
+        int? width = null,
+        ImageMode imageMode =  ImageMode.RGB,
+        IEnumerable<ImageSource> sources = null,
+        ImageType type = ImageType.Filepath,
+        string label = null,
+        decimal? every = null,
+        bool? showLabel = null,
+        bool showDownloadButton = true,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        bool streaming = false,
+        string elemId = null,
+        List<string> elemClasses = null,
+        bool render = true,
+        string key = null,
+        bool mirrorWebcam = true,
+        bool? showShareButton = null)
     {
-        public static Image Image(
-            string value = null,
-            ImageFormat format = ImageFormat.Webp,
-            int? height = null,
-            int? width = null,
-            ImageMode imageMode =  ImageMode.RGB,
-            IEnumerable<ImageSource> sources = null,
-            ImageType type = ImageType.Filepath,
-            string label = null,
-            decimal? every = null,
-            bool? showLabel = null,
-            bool showDownloadButton = true,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            bool streaming = false,
-            string elemId = null,
-            List<string> elemClasses = null,
-            bool render = true,
-            string key = null,
-            bool mirrorWebcam = true,
-            bool? showShareButton = null)
+        Image block = new()
         {
-            var block = new Image()
-            {
-                Format = format,
-                MirrorWebcam = mirrorWebcam,
-                Type = type,
-                Height = height,
-                Width = width,
-                ImageMode = imageMode,
-                Sources = sources == null?(streaming? new List<ImageSource> { ImageSource.Webcam }: new List<ImageSource> { ImageSource.Upload, ImageSource.Webcam, ImageSource.Clipboard }) : sources,
-                Streaming = streaming,
-                ShowDownloadButton = showDownloadButton,
-                
-                ShowShareButton = (GradioUtils.GetSpace() != null) ? showShareButton : true,
-                Label= label,
-                Every= every,
-                ShowLabel= showLabel,
-                Container = container,
-                Scale= scale,
-                MinWidth= minWidth,
-                Interactive= interactive,
-                Visible= visible,
-                ElemId= elemId,
-                ElemClasses= elemClasses,
-                Render= render,
-                Key= key,
-                Value= value,
-            };
+            Format = format,
+            MirrorWebcam = mirrorWebcam,
+            Type = type,
+            Height = height,
+            Width = width,
+            ImageMode = imageMode,
+            Sources = sources == null?(streaming? [ImageSource.Webcam]: [ImageSource.Upload, ImageSource.Webcam, ImageSource.Clipboard]) : sources,
+            Streaming = streaming,
+            ShowDownloadButton = showDownloadButton,
+            
+            ShowShareButton = (GradioUtils.GetSpace() != null) ? showShareButton : true,
+            Label= label,
+            Every= every,
+            ShowLabel= showLabel,
+            Container = container,
+            Scale= scale,
+            MinWidth= minWidth,
+            Interactive= interactive,
+            Visible= visible,
+            ElemId= elemId,
+            ElemClasses= elemClasses,
+            Render= render,
+            Key= key,
+            Value= value,
+        };
 
-            if (streaming && block.Sources.Any(p=>p!= ImageSource.Webcam ))
-            {
-                    throw new ArgumentException("Image streaming only available if sources is ['webcam']. Streaming not supported with multiple sources.");
-            }
-
-            Context.AddToCurrentBlocks(block);
-            return block;
+        if (streaming && block.Sources.Any(p=>p!= ImageSource.Webcam ))
+        {
+                throw new ArgumentException("Image streaming only available if sources is ['webcam']. Streaming not supported with multiple sources.");
         }
+
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Label.cs
+++ b/Gradio.Net/_gr/gr_Label.cs
@@ -1,52 +1,42 @@
-﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Label Label(
+        string value = null,
+        int? numTopClasses = null,
+        string label = null,
+        decimal? every = null,
+        bool? showLabel = null,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+         bool visible = true,
+          string elemId = null,
+           IEnumerable<string> elemClasses = null,
+           bool render = true,
+          string key=null,
+          string color = null
+       )
     {
-        public static Label Label(
-            string value = null,
-            int? numTopClasses = null,
-            string label = null,
-            decimal? every = null,
-            bool? showLabel = null,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-             bool visible = true,
-              string elemId = null,
-               IEnumerable<string> elemClasses = null,
-               bool render = true,
-              string key=null,
-              string color = null
-           )
+        Label block = new()
         {
-            var block = new Label()
-            {
-                Value = value,
-                NumTopClasses= numTopClasses,
-                Label= label,
-                Every = every,
-                ShowLabel= showLabel,
-                Container= container,
-                Scale = scale,
-                MinWidth = minWidth,
-                Visible = visible,
-                ElemId = elemId,
-                ElemClasses = elemClasses,
-                Render = render,
-                Key= key,
-                Color= color,
-            };
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+            Value = value,
+            NumTopClasses= numTopClasses,
+            Label= label,
+            Every = every,
+            ShowLabel= showLabel,
+            Container= container,
+            Scale = scale,
+            MinWidth = minWidth,
+            Visible = visible,
+            ElemId = elemId,
+            ElemClasses = elemClasses,
+            Render = render,
+            Key= key,
+            Color= color,
+        };
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Markdown.cs
+++ b/Gradio.Net/_gr/gr_Markdown.cs
@@ -1,46 +1,39 @@
-﻿using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using System;
-using System.Collections.Generic;
-using System.Reflection.Emit;
-using System.Text;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Markdown Markdown(string value="",
+    string label=null,
+    decimal? every=null,
+    bool showLabel=true,
+    bool rtl  = false,
+    IEnumerable<Dictionary<string,object>> latex_delimiters=null,
+    bool visible  = true,
+    string elemId= null,
+    IEnumerable<string> elemClasses=null,
+    bool render = true,
+    string key =null,
+    bool sanitizeHtml  = true,
+    bool lineBreaks=false,
+    bool headerLinks=false)
     {
-        public static Markdown Markdown(string value="",
-        string label=null,
-        decimal? every=null,
-        bool showLabel=true,
-        bool rtl  = false,
-        IEnumerable<Dictionary<string,object>> latex_delimiters=null,
-        bool visible  = true,
-        string elemId= null,
-        IEnumerable<string> elemClasses=null,
-        bool render = true,
-        string key =null,
-        bool sanitizeHtml  = true,
-        bool lineBreaks=false,
-        bool headerLinks=false)
-        {
-            var block = new Markdown() {
-                Value= value,
-                Label= label,
-                Every= every,
-                ShowLabel= showLabel,
-                Rtl= rtl,
-                LatexDelimiters= latex_delimiters,
-                Visible= visible,
-                ElemId= elemId,
-               ElemClasses= elemClasses,
-               Render= render,
-                Key= key,
-                SanitizeHtml= sanitizeHtml,
-                LineBreaks= lineBreaks,
-                HeaderLinks= headerLinks,
-            };
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        Markdown block = new() {
+            Value= value,
+            Label= label,
+            Every= every,
+            ShowLabel= showLabel,
+            Rtl= rtl,
+            LatexDelimiters= latex_delimiters,
+            Visible= visible,
+            ElemId= elemId,
+           ElemClasses= elemClasses,
+           Render= render,
+            Key= key,
+            SanitizeHtml= sanitizeHtml,
+            LineBreaks= lineBreaks,
+            HeaderLinks= headerLinks,
+        };
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_MultimodalTextbox.cs
+++ b/Gradio.Net/_gr/gr_MultimodalTextbox.cs
@@ -1,67 +1,58 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static MultimodalTextbox MultimodalTextbox(
+        Dictionary<string,object> value = null,
+        IEnumerable<string> fileTypes =null,
+        int lines = 1,
+        int maxLines = 20,
+        string placeholder = null,
+        string label = null,
+        string info = null,
+        decimal? every = null,
+        bool showLabel = true,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        bool autofocus = false,
+        bool autoscroll = true,
+        IEnumerable<string> elemClasses = null,
+        bool render = true,
+        TextboxTextAlign textAlign = TextboxTextAlign.Left,
+        bool rtl = false,
+        object submitBtn = null)
     {
-        public static MultimodalTextbox MultimodalTextbox(
-            Dictionary<string,object> value = null,
-            IEnumerable<string> fileTypes =null,
-            int lines = 1,
-            int maxLines = 20,
-            string placeholder = null,
-            string label = null,
-            string info = null,
-            decimal? every = null,
-            bool showLabel = true,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            bool autofocus = false,
-            bool autoscroll = true,
-            IEnumerable<string> elemClasses = null,
-            bool render = true,
-            TextboxTextAlign textAlign = TextboxTextAlign.Left,
-            bool rtl = false,
-            object submitBtn = null)
+        MultimodalTextbox blocks = new()
         {
-            var blocks = new MultimodalTextbox()
-            {
-                Value = value,
-                Lines = lines,
-                MaxLines = maxLines,
-                Placeholder = placeholder,
-                Label = label,
-                Info = info,
-                Every = every,
-                ShowLabel = showLabel,
-                Container = container,
-                Scale = scale,
-                MinWidth = minWidth,
-                Interactive = interactive,
-                Visible = visible,
-                ElemId = elemId,
-                Autofocus = autofocus,
-                Autoscroll = autoscroll,
-                ElemClasses = elemClasses,
-                Render = render,
-                TextAlign = textAlign,
-                Rtl = rtl,
-                SubmitBtn = submitBtn
-            };
-            Context.AddToCurrentBlocks(blocks);
-            return blocks;
-        }
+            Value = value,
+            Lines = lines,
+            MaxLines = maxLines,
+            Placeholder = placeholder,
+            Label = label,
+            Info = info,
+            Every = every,
+            ShowLabel = showLabel,
+            Container = container,
+            Scale = scale,
+            MinWidth = minWidth,
+            Interactive = interactive,
+            Visible = visible,
+            ElemId = elemId,
+            Autofocus = autofocus,
+            Autoscroll = autoscroll,
+            ElemClasses = elemClasses,
+            Render = render,
+            TextAlign = textAlign,
+            Rtl = rtl,
+            SubmitBtn = submitBtn
+        };
+        Context.AddToCurrentBlocks(blocks);
+        return blocks;
     }
 }

--- a/Gradio.Net/_gr/gr_Number.cs
+++ b/Gradio.Net/_gr/gr_Number.cs
@@ -1,58 +1,47 @@
-﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Number Number(
+        decimal? value = null,
+        string label = null,
+        string info = null,
+        decimal? every = null,
+        bool showLabel = true,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true,
+        int? precision = null,
+        decimal? minimum=null,
+        decimal? maximum=null,
+        decimal step =1)
     {
-        public static Number Number(
-            decimal? value = null,
-            string label = null,
-            string info = null,
-            decimal? every = null,
-            bool showLabel = true,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true,
-            int? precision = null,
-            decimal? minimum=null,
-            decimal? maximum=null,
-            decimal step =1)
+        Number blocks = new()
         {
-            var blocks = new Number()
-            {
-                Value = value,
-                Label = label,
-                Info = info,
-                Every = every,
-                ShowLabel = showLabel,
-                Container = container,
-                Scale = scale,
-                MinWidth = minWidth,
-                Interactive = interactive,
-                Visible = visible,
-                ElemId = elemId,                
-                ElemClasses = elemClasses,
-                Render = render,
-                Precision= precision,
-                Minimum= minimum,
-                Maximum= maximum,
-                Step= step
-            };
-            Context.AddToCurrentBlocks(blocks);
-            return blocks;
-        }
+            Value = value,
+            Label = label,
+            Info = info,
+            Every = every,
+            ShowLabel = showLabel,
+            Container = container,
+            Scale = scale,
+            MinWidth = minWidth,
+            Interactive = interactive,
+            Visible = visible,
+            ElemId = elemId,                
+            ElemClasses = elemClasses,
+            Render = render,
+            Precision= precision,
+            Minimum= minimum,
+            Maximum= maximum,
+            Step= step
+        };
+        Context.AddToCurrentBlocks(blocks);
+        return blocks;
     }
 }

--- a/Gradio.Net/_gr/gr_Output.cs
+++ b/Gradio.Net/_gr/gr_Output.cs
@@ -1,39 +1,30 @@
-﻿
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+﻿namespace Gradio.Net;
 
-
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    internal static Input Input(BlockFunction blockFunction, params object[] data)
     {
-        internal static Input Input(BlockFunction blockFunction, params object[] data)
+        for (int i = 0; i < data.Length; i++)
         {
-            for (int i = 0; i < data.Length; i++)
-            {
-                data[i] = blockFunction.Inputs.ElementAt(i).PreProcess(data[i]);
-            }
-            return new Input { Data = data };
+            data[i] = blockFunction.Inputs.ElementAt(i).PreProcess(data[i]);
         }
-        public static Output Output(params object[] data)
+        return new Input { Data = data };
+    }
+    public static Output Output(params object[] data)
+    {
+        return new Output { Data = data };
+    }
+
+    internal static object[] Output(EventResult eventResult, params object[] data)
+    {
+        BlockFunction blockFunction = eventResult.BlockFunction;
+        string rootUrl = eventResult.Event.RootUrl;
+
+        for (int i = 0; i < data.Length; i++)
         {
-            return new Output { Data = data };
+            data[i] = blockFunction.Outputs.ElementAt(i).PostProcess(rootUrl, data[i]);
         }
 
-        internal static object[] Output(EventResult eventResult, params object[] data)
-        {
-            var blockFunction = eventResult.BlockFunction;
-            var rootUrl = eventResult.Event.RootUrl;
-
-            for (int i = 0; i < data.Length; i++)
-            {
-                data[i] = blockFunction.Outputs.ElementAt(i).PostProcess(rootUrl, data[i]);
-            }
-
-            return data;
-        }
+        return data;
     }
 }

--- a/Gradio.Net/_gr/gr_Radio.cs
+++ b/Gradio.Net/_gr/gr_Radio.cs
@@ -1,56 +1,46 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using System.Xml.Linq;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Radio Radio(
+        IEnumerable<string> choices = null,
+        object value = null,
+        RadioType type = RadioType.Value,           
+        string label = null,
+        string info = null,
+        decimal? every = null,
+        bool? showLabel = null,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true
+    )
     {
-        public static Radio Radio(
-            IEnumerable<string> choices = null,
-            object value = null,
-            RadioType type = RadioType.Value,           
-            string label = null,
-            string info = null,
-            decimal? every = null,
-            bool? showLabel = null,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true
-        )
-        { 
-            var block = new Radio();
-            block.Choices = choices;
-            block.Type = type;
-                     
-            block.Label = label;
-            block.Info = info;
-            block.Every = every;
-            block.ShowLabel = showLabel;
-            block.Container = container;
-            block.Scale = scale;
-            block.MinWidth = minWidth;
-            block.Interactive = interactive;
-            block.Visible = visible;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
-            block.Value = value;
-            
-            Context.AddToCurrentBlocks(block);
-            return block;
-        }
+        Radio block = new();
+        block.Choices = choices;
+        block.Type = type;
+                 
+        block.Label = label;
+        block.Info = info;
+        block.Every = every;
+        block.ShowLabel = showLabel;
+        block.Container = container;
+        block.Scale = scale;
+        block.MinWidth = minWidth;
+        block.Interactive = interactive;
+        block.Visible = visible;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
+        block.Value = value;
+        
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Row.cs
+++ b/Gradio.Net/_gr/gr_Row.cs
@@ -1,30 +1,26 @@
 ﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Row Row(
+        RowVariant variant = RowVariant.Default,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true,
+        bool equalHeight = true)
     {
-        public static Row Row(
-            RowVariant variant = RowVariant.Default,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true,
-            bool equalHeight = true)
-        {
-            var blocks = new Row() {
-                Variant= variant,
-                Visible= visible,
-                ElemId= elemId,
-                ElemClasses= elemClasses,
-                Render= render,
-                EqualHeight= equalHeight,
-            };
-            Context.SetCurrentBlocks(blocks);
-            return blocks;
-        }
+        Row blocks = new() {
+            Variant= variant,
+            Visible= visible,
+            ElemId= elemId,
+            ElemClasses= elemClasses,
+            Render= render,
+            EqualHeight= equalHeight,
+        };
+        Context.SetCurrentBlocks(blocks);
+        return blocks;
     }
 }

--- a/Gradio.Net/_gr/gr_Slider.cs
+++ b/Gradio.Net/_gr/gr_Slider.cs
@@ -1,69 +1,58 @@
-﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+   
+    public static Slider Slider(
+        decimal minimum = 0,
+        decimal maximum = 100,            
+        decimal? value = null,
+        decimal? step = null,
+        string label = null,
+        string info = null,
+        decimal? every = null,
+        bool showLabel = true,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        IEnumerable<string> elemClasses = null,
+        bool render = true,
+        bool randomize =false
+        )
     {
-       
-        public static Slider Slider(
-            decimal minimum = 0,
-            decimal maximum = 100,            
-            decimal? value = null,
-            decimal? step = null,
-            string label = null,
-            string info = null,
-            decimal? every = null,
-            bool showLabel = true,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            IEnumerable<string> elemClasses = null,
-            bool render = true,
-            bool randomize =false
-            )
+        Slider block = new()
         {
-            var block = new Slider()
-            {
-                Value = value,
-                Label = label,
-                Info = info,
-                Every = every,
-                ShowLabel = showLabel,
-                Container = container,
-                Scale = scale,
-                MinWidth = minWidth,
-                Interactive = interactive,
-                Visible = visible,
-                ElemId = elemId,                
-                ElemClasses = elemClasses,
-                Render = render,
-            };
-            block.Minimum = minimum;
-            block.Maximum = maximum;
-            if (step == null)
-            {
-                var difference = maximum - minimum;
-                var power = Math.Floor(Math.Log10( double.Parse(difference.ToString())) - 2);
-                block.Step =decimal.Parse( Math.Pow( 10,double.Parse(power.ToString())).ToString());
-            }
-            else
-                block.Step = step.Value;
-            if (randomize)
-                value = block.GetRandomValue();
-
-            Context.AddToCurrentBlocks(block);
-            return block;
+            Value = value,
+            Label = label,
+            Info = info,
+            Every = every,
+            ShowLabel = showLabel,
+            Container = container,
+            Scale = scale,
+            MinWidth = minWidth,
+            Interactive = interactive,
+            Visible = visible,
+            ElemId = elemId,                
+            ElemClasses = elemClasses,
+            Render = render,
+        };
+        block.Minimum = minimum;
+        block.Maximum = maximum;
+        if (step == null)
+        {
+            decimal difference = maximum - minimum;
+            double power = Math.Floor(Math.Log10( double.Parse(difference.ToString())) - 2);
+            block.Step =decimal.Parse( Math.Pow( 10,double.Parse(power.ToString())).ToString());
         }
+        else
+            block.Step = step.Value;
+        if (randomize)
+            value = block.GetRandomValue();
+
+        Context.AddToCurrentBlocks(block);
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_Tab.cs
+++ b/Gradio.Net/_gr/gr_Tab.cs
@@ -1,28 +1,21 @@
-﻿using Gradio.Net.Enums;
-using System;
-using System.Collections.Generic;
-using System.Reflection.Emit;
-using System.Text;
+﻿namespace Gradio.Net;
 
-namespace Gradio.Net
+public static partial class gr
 {
-    public static partial class gr
+    public static Tab Tab(string label = null,bool visible =true,bool interactive= true, string componentId = null, string elemId = null, string[] elemClasses = null,bool render= true)
     {
-        public static Tab Tab(string label = null,bool visible =true,bool interactive= true, string componentId = null, string elemId = null, string[] elemClasses = null,bool render= true)
-        {
-            var block = new Tab();
+        Tab block = [];
 
-            block.Label = label;
-            block.Visible = visible;
-            block.Interactive = interactive;
-            block.ComponentId = componentId;
-            block.ElemId = elemId;
-            block.ElemClasses = elemClasses;
-            block.Render = render;
+        block.Label = label;
+        block.Visible = visible;
+        block.Interactive = interactive;
+        block.ComponentId = componentId;
+        block.ElemId = elemId;
+        block.ElemClasses = elemClasses;
+        block.Render = render;
 
-            Context.SetCurrentBlocks(block);
+        Context.SetCurrentBlocks(block);
 
-            return block;
-        }
+        return block;
     }
 }

--- a/Gradio.Net/_gr/gr_TextBox.cs
+++ b/Gradio.Net/_gr/gr_TextBox.cs
@@ -1,68 +1,59 @@
 ﻿using Gradio.Net.Enums;
-using Microsoft.VisualBasic;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection.Emit;
-using System.Text;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace Gradio.Net
+namespace Gradio.Net;
+
+public static partial class gr
 {
-    public static partial class gr
+    public static Textbox Textbox(
+        string value = null,
+        int lines = 1,
+        int maxLines = 20,
+        string placeholder = null,
+        string label = null,
+        string info = null,
+        decimal? every = null,
+        bool showLabel = true,
+        bool container = true,
+        int? scale = null,
+        int minWidth = 160,
+        bool? interactive = null,
+        bool visible = true,
+        string elemId = null,
+        bool autofocus = false,
+        bool autoscroll = true,
+        IEnumerable<string> elemClasses = null,
+        bool render = true,
+        TextboxType type = TextboxType.Text,
+        TextboxTextAlign textAlign = TextboxTextAlign.Left,
+        bool rtl = false,
+        bool showCopyButton = false)
     {
-        public static Textbox Textbox(
-            string value = null,
-            int lines = 1,
-            int maxLines = 20,
-            string placeholder = null,
-            string label = null,
-            string info = null,
-            decimal? every = null,
-            bool showLabel = true,
-            bool container = true,
-            int? scale = null,
-            int minWidth = 160,
-            bool? interactive = null,
-            bool visible = true,
-            string elemId = null,
-            bool autofocus = false,
-            bool autoscroll = true,
-            IEnumerable<string> elemClasses = null,
-            bool render = true,
-            TextboxType type = TextboxType.Text,
-            TextboxTextAlign textAlign = TextboxTextAlign.Left,
-            bool rtl = false,
-            bool showCopyButton = false)
+        Textbox blocks = new()
         {
-            var blocks = new Textbox()
-            {
-                Value = value,
-                Lines = lines,
-                MaxLines = maxLines,
-                Placeholder = placeholder,
-                Label = label,
-                Info = info,
-                Every = every,
-                ShowLabel = showLabel,
-                Container = container,
-                Scale = scale,
-                MinWidth = minWidth,
-                Interactive = interactive,
-                Visible = visible,
-                ElemId = elemId,
-                Autofocus = autofocus,
-                Autoscroll = autoscroll,
-                ElemClasses = elemClasses,
-                Render = render,
-                Type = type,
-                TextAlign = textAlign,
-                Rtl = rtl,
-                ShowCopyButton = showCopyButton
-            };
-            Context.AddToCurrentBlocks(blocks);
-            return blocks;
-        }
+            Value = value,
+            Lines = lines,
+            MaxLines = maxLines,
+            Placeholder = placeholder,
+            Label = label,
+            Info = info,
+            Every = every,
+            ShowLabel = showLabel,
+            Container = container,
+            Scale = scale,
+            MinWidth = minWidth,
+            Interactive = interactive,
+            Visible = visible,
+            ElemId = elemId,
+            Autofocus = autofocus,
+            Autoscroll = autoscroll,
+            ElemClasses = elemClasses,
+            Render = render,
+            Type = type,
+            TextAlign = textAlign,
+            Rtl = rtl,
+            ShowCopyButton = showCopyButton
+        };
+        Context.AddToCurrentBlocks(blocks);
+        return blocks;
     }
 }

--- a/Gradio.Net/jinja2/Block.cs
+++ b/Gradio.Net/jinja2/Block.cs
@@ -1,28 +1,19 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.jinja2;
 
-namespace Gradio.Net.jinja2
+internal abstract class Block
 {
-    internal abstract class Block
+    internal Block(string content)
+    { 
+        Content = content;
+    }
+    internal virtual BlockTypes Type => BlockTypes.Undefined;
+
+    internal string Content { get; private set; }
+
+    internal abstract string Render(Dictionary<string,object> vars);
+
+    public override string ToString()
     {
-        internal Block(string content)
-        { 
-            Content = content;
-        }
-        internal virtual BlockTypes Type => BlockTypes.Undefined;
-
-        internal string Content { get; private set; }
-
-        internal abstract string Render(Dictionary<string,object> vars);
-
-        public override string ToString()
-        {
-            return $"{Type}:{Content}";
-        }
+        return $"{Type}:{Content}";
     }
 }

--- a/Gradio.Net/jinja2/BlockTypes.cs
+++ b/Gradio.Net/jinja2/BlockTypes.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.jinja2;
 
-namespace Gradio.Net.jinja2
+internal enum BlockTypes
 {
-    internal enum BlockTypes
-    {
-        Undefined = 0,
-        Text = 1,
-        Code = 2,
-    }
+    Undefined = 0,
+    Text = 1,
+    Code = 2,
 }

--- a/Gradio.Net/jinja2/CodeBlock.cs
+++ b/Gradio.Net/jinja2/CodeBlock.cs
@@ -1,70 +1,62 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
-namespace Gradio.Net.jinja2
+namespace Gradio.Net.jinja2;
+
+internal sealed class CodeBlock : Block
 {
-    internal sealed class CodeBlock : Block
+    internal CodeBlock(string content):base(content) { }
+
+    internal override BlockTypes Type => BlockTypes.Code;
+
+    internal override string Render(Dictionary<string, object> vars)
     {
-        internal CodeBlock(string content):base(content) { }
+        //todo: dynamic render
 
-        internal override BlockTypes Type => BlockTypes.Code;
-
-        internal override string Render(Dictionary<string, object> vars)
+        if (this.Content.Equals("config | toorjson"))
         {
-            //todo: dynamic render
-
-            if (this.Content.Equals("config | toorjson"))
-            {
-                return JsonSerializer.Serialize(vars["config"]); 
-            }
-            else if (this.Content.StartsWith("config['"))
-            {
-                if (vars["config"] is Dictionary<string, object> dictConfig)
-                {
-                    Regex regex = new Regex(@"config\['(.*?)'\]");
-                    var match = regex.Match(this.Content);
-                    var key = match.Groups[1].Value;
-                    if (dictConfig.ContainsKey(key))
-                    {
-                        return dictConfig[key].ToString();
-                    }
-
-                    return "";
-                }
-            }
-            else if (this.Content.StartsWith("config.get('"))
-            {
-                if (vars["config"] is Dictionary<string, object> dictConfig)
-                {
-                    Regex regex = new Regex(@"config.get\('(.*?)', \{\}\)\.get\('(.*?)', '(.*?)'\)");
-                    var match = regex.Match(this.Content);
-                    var key = match.Groups[1].Value;
-                    if (dictConfig.ContainsKey(key))
-                    {
-                        if (dictConfig[key] is Dictionary<string, object> dictInner)
-                        {
-                            var innerKey = match.Groups[2].Value;
-                            if (dictInner.ContainsKey(innerKey))
-                            {
-                                return dictInner[innerKey].ToString();
-                            }
-
-                            
-                        }
-                    }
-
-                    return match.Groups[3].Value;
-                }
-            }
-
-            return this.Content;
+            return JsonSerializer.Serialize(vars["config"]); 
         }
+        else if (this.Content.StartsWith("config['"))
+        {
+            if (vars["config"] is Dictionary<string, object> dictConfig)
+            {
+                Regex regex = new(@"config\['(.*?)'\]");
+                Match match = regex.Match(this.Content);
+                string key = match.Groups[1].Value;
+                if (dictConfig.ContainsKey(key))
+                {
+                    return dictConfig[key].ToString();
+                }
+
+                return "";
+            }
+        }
+        else if (this.Content.StartsWith("config.get('"))
+        {
+            if (vars["config"] is Dictionary<string, object> dictConfig)
+            {
+                Regex regex = new(@"config.get\('(.*?)', \{\}\)\.get\('(.*?)', '(.*?)'\)");
+                Match match = regex.Match(this.Content);
+                string key = match.Groups[1].Value;
+                if (dictConfig.ContainsKey(key))
+                {
+                    if (dictConfig[key] is Dictionary<string, object> dictInner)
+                    {
+                        string innerKey = match.Groups[2].Value;
+                        if (dictInner.ContainsKey(innerKey))
+                        {
+                            return dictInner[innerKey].ToString();
+                        }
+
+                        
+                    }
+                }
+
+                return match.Groups[3].Value;
+            }
+        }
+
+        return this.Content;
     }
 }

--- a/Gradio.Net/jinja2/Template.cs
+++ b/Gradio.Net/jinja2/Template.cs
@@ -1,29 +1,25 @@
-﻿using Gradio.Net.jinja2;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text;
 
-namespace Gradio.Net.jinja2
+namespace Gradio.Net.jinja2;
+
+internal class Template
 {
-    internal class Template
+    private readonly string _source;
+
+    internal Template(string source)
     {
-        private readonly string _source;
+        this._source = source;
 
-        internal Template(string source)
+    }
+
+    internal string Render(Dictionary<string, object> vars)
+    {
+        List<Block> blocks = new TemplateTokenizer().Tokenize(this._source);
+        StringBuilder result = new();
+        foreach (Block block in blocks )
         {
-            this._source = source;
-
+            result.Append(block.Render(vars));
         }
-
-        internal string Render(Dictionary<string, object> vars)
-        {
-            var blocks = new TemplateTokenizer().Tokenize(this._source);
-            var result = new StringBuilder();
-            foreach ( var block in blocks )
-            {
-                result.Append(block.Render(vars));
-            }
-            return result.ToString();
-        }
+        return result.ToString();
     }
 }

--- a/Gradio.Net/jinja2/TemplateTokenizer.cs
+++ b/Gradio.Net/jinja2/TemplateTokenizer.cs
@@ -1,84 +1,75 @@
-﻿using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.jinja2;
 
-namespace Gradio.Net.jinja2
+internal sealed class TemplateTokenizer()
 {
-    internal sealed class TemplateTokenizer()
+    internal List<Block> Tokenize(string? text)
     {
-        internal List<Block> Tokenize(string? text)
+        const char BlockStarter = '{';
+        const char BlockEnder = '}';
+
+        List<Block> blocks = [];
+
+        int endOfLastBlock = 0;
+
+        int blockStartPos = 0;
+        bool blockStartFound = false;
+
+        bool insideTextValue = false;
+        char textValueDelimiter = '\0';
+
+        bool skipNextChar = false;
+        char nextChar = text[0];
+        for (int nextCharCursor = 1; nextCharCursor < text.Length; nextCharCursor++)
         {
-            const char BlockStarter = '{';
-            const char BlockEnder = '}';
+            int currentCharPos = nextCharCursor - 1;
+            int cursor = nextCharCursor;
+            char currentChar = nextChar;
+            nextChar = text[nextCharCursor];
 
-            var blocks = new List<Block>();
-
-            var endOfLastBlock = 0;
-
-            var blockStartPos = 0;
-            var blockStartFound = false;
-
-            var insideTextValue = false;
-            var textValueDelimiter = '\0';
-
-            bool skipNextChar = false;
-            char nextChar = text[0];
-            for (int nextCharCursor = 1; nextCharCursor < text.Length; nextCharCursor++)
+            if (skipNextChar)
             {
-                int currentCharPos = nextCharCursor - 1;
-                int cursor = nextCharCursor;
-                char currentChar = nextChar;
-                nextChar = text[nextCharCursor];
+                skipNextChar = false;
+                continue;
+            }
 
-                if (skipNextChar)
-                {
-                    skipNextChar = false;
-                    continue;
-                }
+            // When "{{" is found outside a value
+            // Note: "{{ {{x}}" => ["{{ ", "{{x}}"]
+            if (!insideTextValue && currentChar == BlockStarter && nextChar == BlockStarter)
+            {
+                // A block starts at the first "{"
+                blockStartPos = currentCharPos;
+                blockStartFound = true;
+            }
 
-                // When "{{" is found outside a value
-                // Note: "{{ {{x}}" => ["{{ ", "{{x}}"]
-                if (!insideTextValue && currentChar == BlockStarter && nextChar == BlockStarter)
+            // After having found '{{'
+            if (blockStartFound)
+            {
+                if (currentChar == BlockEnder && nextChar == BlockEnder)
                 {
-                    // A block starts at the first "{"
-                    blockStartPos = currentCharPos;
-                    blockStartFound = true;
-                }
-
-                // After having found '{{'
-                if (blockStartFound)
-                {
-                    if (currentChar == BlockEnder && nextChar == BlockEnder)
+                    // If there is plain text between the current var/val/code block and the previous one, capture that as a TextBlock
+                    if (blockStartPos > endOfLastBlock)
                     {
-                        // If there is plain text between the current var/val/code block and the previous one, capture that as a TextBlock
-                        if (blockStartPos > endOfLastBlock)
-                        {
-                            blocks.Add(new TextBlock(text.Substring(endOfLastBlock, blockStartPos - endOfLastBlock)));
-                        }
-                        // Extract raw block
-                        var contentWithDelimiters = text.Substring(blockStartPos, cursor- blockStartPos + 1).Trim();
-
-                            // Remove "{{" and "}}" delimiters and trim empty chars
-                            var contentWithoutDelimiters = contentWithDelimiters
-                                .Substring(2, contentWithDelimiters.Length- 4)
-                                .Trim();
-
-                            blocks.Add(new CodeBlock(contentWithoutDelimiters));
-                            
-                            endOfLastBlock = cursor + 1;
-                            blockStartFound = false;
+                        blocks.Add(new TextBlock(text.Substring(endOfLastBlock, blockStartPos - endOfLastBlock)));
                     }
+                    // Extract raw block
+                    string contentWithDelimiters = text.Substring(blockStartPos, cursor- blockStartPos + 1).Trim();
+
+                    // Remove "{{" and "}}" delimiters and trim empty chars
+                    string contentWithoutDelimiters = contentWithDelimiters
+                            .Substring(2, contentWithDelimiters.Length- 4)
+                            .Trim();
+
+                        blocks.Add(new CodeBlock(contentWithoutDelimiters));
+                        
+                        endOfLastBlock = cursor + 1;
+                        blockStartFound = false;
                 }
             }
-            if (endOfLastBlock < text.Length)
-            {
-                blocks.Add(new TextBlock(text.Substring( endOfLastBlock, text.Length- endOfLastBlock)));
-            }
-            return blocks;
         }
+        if (endOfLastBlock < text.Length)
+        {
+            blocks.Add(new TextBlock(text.Substring( endOfLastBlock, text.Length- endOfLastBlock)));
+        }
+        return blocks;
     }
 }

--- a/Gradio.Net/jinja2/TextBlock.cs
+++ b/Gradio.Net/jinja2/TextBlock.cs
@@ -1,21 +1,13 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace Gradio.Net.jinja2;
 
-namespace Gradio.Net.jinja2
+internal sealed class TextBlock : Block
 {
-    internal sealed class TextBlock : Block
+    internal TextBlock(string content):base(content) { }
+
+    internal override BlockTypes Type => BlockTypes.Text;
+
+    internal override string Render(Dictionary<string, object> vars)
     {
-        internal TextBlock(string content):base(content) { }
-
-        internal override BlockTypes Type => BlockTypes.Text;
-
-        internal override string Render(Dictionary<string, object> vars)
-        {
-            return this.Content;
-        }
+        return this.Content;
     }
 }

--- a/demo/ChatbotDemo.cs
+++ b/demo/ChatbotDemo.cs
@@ -1,32 +1,30 @@
 ﻿using Gradio.Net;
-using System;
 
-namespace demo
+namespace demo;
+
+public static class ChatbotDemo
 {
-    public static class ChatbotDemo
+    public static async Task Create()
     {
-        public static async Task Create()
+        gr.Markdown("# Chatbot Demo");
+
+        Chatbot chatbot = gr.Chatbot();
+        Textbox msg = gr.Textbox(placeholder:"Enter to Submit");
+
+        await msg.Submit(streamingFn: (input) => Respond(Textbox.Payload(input.Data[0]), Chatbot.Payload(input.Data[1])),
+            inputs: [msg, chatbot], outputs: [msg, chatbot]);
+    }
+
+    static async IAsyncEnumerable<Output> Respond(string message, IList<ChatbotMessagePair> chatHistory)
+    {
+        chatHistory.Add(new ChatbotMessagePair(message,""));
+        message = "You typed: " + message;
+        for (int i = 0; i < message.Length; i++)
         {
-            gr.Markdown("# Chatbot Demo");
+            await Task.Delay(500);
+            chatHistory.Last().AiMessage.TextMessage += message[i];
 
-            var chatbot = gr.Chatbot();
-            var msg = gr.Textbox(placeholder:"Enter to Submit");
-
-            await msg.Submit(streamingFn: (input) => Respond(Textbox.Payload(input.Data[0]), Chatbot.Payload(input.Data[1])),
-                inputs: new Component[] { msg, chatbot }, outputs: new Component[] { msg, chatbot });
-        }
-
-        static async IAsyncEnumerable<Output> Respond(string message, IList<ChatbotMessagePair> chatHistory)
-        {
-            chatHistory.Add(new ChatbotMessagePair(message,""));
-            message = "You typed: " + message;
-            for (int i = 0; i < message.Length; i++)
-            {
-                await Task.Delay(500);
-                chatHistory.Last().AiMessage.TextMessage += message[i];
-
-                yield return gr.Output("", chatHistory);
-            }
+            yield return gr.Output("", chatHistory);
         }
     }
 }

--- a/demo/FirstDemo.cs
+++ b/demo/FirstDemo.cs
@@ -1,22 +1,21 @@
 ﻿using Gradio.Net;
 
-namespace demo
-{
-    public static class FirstDemo
-    {
-        public static async Task Create()
-        {
-            gr.Markdown("# First Demo");
+namespace demo;
 
-            gr.Markdown("Start typing below and then click **Run** to see the output.");
-            Textbox input, output;
-            using (gr.Row())
-            {
-                input = gr.Textbox(placeholder: "What is your name?");
-                output = gr.Textbox();
-            }
-            var btn = gr.Button("Run");
-            await btn.Click(fn: async (input) => gr.Output($"Welcome to Gradio.Net, {Textbox.Payload(input.Data[0])}!"), inputs: new[] { input }, outputs: new[] { output });
+public static class FirstDemo
+{
+    public static async Task Create()
+    {
+        gr.Markdown("# First Demo");
+
+        gr.Markdown("Start typing below and then click **Run** to see the output.");
+        Textbox input, output;
+        using (gr.Row())
+        {
+            input = gr.Textbox(placeholder: "What is your name?");
+            output = gr.Textbox();
         }
+        Button btn = gr.Button("Run");
+        await btn.Click(fn: async (input) => gr.Output($"Welcome to Gradio.Net, {Textbox.Payload(input.Data[0])}!"), inputs: [input], outputs: [output]);
     }
 }

--- a/demo/FormDemo.cs
+++ b/demo/FormDemo.cs
@@ -1,34 +1,31 @@
 ﻿using Gradio.Net;
-using System.Reflection.Emit;
-using static System.Formats.Asn1.AsnWriter;
-using static System.Net.Mime.MediaTypeNames;
 
-namespace demo
+namespace demo;
+
+public static class FormDemo
 {
-    public static class FormDemo
+    public static async Task Create()
     {
-        public static async Task Create()
+        gr.Markdown("# FormDemo Demo");
+
+        gr.HTML(value: "<p style='margin-top: 1rem, margin-bottom: 1rem'>This <em>example</em> was <strong>written</strong> in <a href='https://en.wikipedia.org/wiki/HTML' _target='blank'>HTML</a> </p>");
+
+
+        using (gr.Column())
         {
-            gr.Markdown("# FormDemo Demo");
+            Textbox text1 = gr.Textbox();
+            Dropdown dropdown1 = gr.Dropdown(choices: ["First Choice", "Second Choice", "Third Choice"]);
+            Checkbox checkbox1 = gr.Checkbox();
+            CheckboxGroup checkboxGroup1 = gr.CheckboxGroup(choices: ["First Choice", "Second Choice", "Third Choice"]);
+            MultimodalTextbox multimodalTextbox1 = gr.MultimodalTextbox(interactive:true);
+            Number number1 = gr.Number();
+            Radio radio1 = gr.Radio(choices: ["First Choice", "Second Choice", "Third Choice"]);
+            Slider slider1 = gr.Slider();
 
-            gr.HTML(value: "<p style='margin-top: 1rem, margin-bottom: 1rem'>This <em>example</em> was <strong>written</strong> in <a href='https://en.wikipedia.org/wiki/HTML' _target='blank'>HTML</a> </p>");
+            Textbox text_Result = gr.Textbox(label:"Form Value", interactive:false);
 
-
-            using (gr.Column())
-            {
-                var text1 = gr.Textbox();
-                var dropdown1 = gr.Dropdown(choices: new[] { "First Choice", "Second Choice", "Third Choice" });
-                var checkbox1 = gr.Checkbox();
-                var checkboxGroup1 = gr.CheckboxGroup(choices: new[] { "First Choice", "Second Choice", "Third Choice" });
-                var multimodalTextbox1 = gr.MultimodalTextbox(interactive:true);               
-                var number1 = gr.Number();
-                var radio1 = gr.Radio(choices: ["First Choice", "Second Choice", "Third Choice"]);
-                var slider1 = gr.Slider();
-
-                var text_Result = gr.Textbox(label:"Form Value", interactive:false);
-
-                var btn = gr.Button("Run");
-                await btn.Click(fn: async (input) => gr.Output($@"
+            Button btn = gr.Button("Run");
+            await btn.Click(fn: async (input) => gr.Output($@"
 Textbox: {Textbox.Payload(input.Data[0])}
 Dropdown: {string.Join(", ",Dropdown.Payload(input.Data[1]))}
 Checkbox: {Checkbox.Payload(input.Data[2])}
@@ -37,8 +34,7 @@ MultimodalTextbox: {MultimodalTextbox.Payload(input.Data[4]).Files.FirstOrDefaul
 Number: {Number.Payload(input.Data[5])}
 Radio: {string.Join(", ", Radio.Payload(input.Data[6]))}
 Slider: {Slider.Payload(input.Data[7])}
-"), inputs: new Component[] { text1, dropdown1, checkbox1, checkboxGroup1, multimodalTextbox1, number1, radio1, slider1 }, outputs: new[] { text_Result });
-            }
+"), inputs: [text1, dropdown1, checkbox1, checkboxGroup1, multimodalTextbox1, number1, radio1, slider1], outputs: [text_Result]);
         }
     }
 }

--- a/demo/ImageDemo.cs
+++ b/demo/ImageDemo.cs
@@ -4,71 +4,70 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.Processing;
 
-namespace demo
+namespace demo;
+
+public static class ImageDemo
 {
-    public static class ImageDemo
+    public static async Task Create()
     {
-        public static async Task Create()
+        gr.Markdown("# Image Demo");
+
+        gr.Markdown("upload a image and click button");
+        Gradio.Net.Image input, outputFilePath, outputUrl;
+        using (gr.Row())
         {
-            gr.Markdown("# Image Demo");
+            input = gr.Image();
 
-            gr.Markdown("upload a image and click button");
-            Gradio.Net.Image input, outputFilePath, outputUrl;
-            using (gr.Row())
+            outputFilePath = gr.Image();
+            outputUrl = gr.Image();
+
+        }
+        Button btn = gr.Button("Submit");
+        await btn.Click(fn: async (input) => gr.Output(DrawWaterMarkOnImage(Gradio.Net.Image.Payload(input.Data[0])), "https://www.nuget.org/profiles/MyIO/avatar?imageSize=64"), inputs: [input], outputs: [outputFilePath, outputUrl]);
+    }
+
+    static string DrawWaterMarkOnImage(string inputImageFilePath)
+    {
+        using (SixLabors.ImageSharp.Image img = SixLabors.ImageSharp.Image.Load(inputImageFilePath))
+        {
+            string outputFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".png");
+            Font font = SystemFonts.CreateFont("Arial", 10); // for scaling water mark size is largely ignored.
+
+            using (SixLabors.ImageSharp.Image img2 = img.Clone(ctx => ApplyScalingWaterMarkSimple(ctx, font, "Gradio.Net", Color.HotPink, 5)))
             {
-                input = gr.Image();
-
-                outputFilePath = gr.Image();
-                outputUrl = gr.Image();
-
+                img2.Save(outputFilePath);
             }
-            var btn = gr.Button("Submit");
-            await btn.Click(fn: async (input) => gr.Output(DrawWaterMarkOnImage(Gradio.Net.Image.Payload(input.Data[0])), "https://www.nuget.org/profiles/MyIO/avatar?imageSize=64"), inputs: new[] { input }, outputs: new[] { outputFilePath, outputUrl });
+            return outputFilePath;
         }
 
-        static string DrawWaterMarkOnImage(string inputImageFilePath)
+    }
+    static IImageProcessingContext ApplyScalingWaterMarkSimple(IImageProcessingContext processingContext,
+              Font font,
+              string text,
+              Color color,
+              float padding)
+    {
+        Size imgSize = processingContext.GetCurrentSize();
+
+        float targetWidth = imgSize.Width - (padding * 2);
+        float targetHeight = imgSize.Height - (padding * 2);
+
+        // Measure the text size
+        FontRectangle size = TextMeasurer.MeasureSize(text, new TextOptions(font));
+
+        // Find out how much we need to scale the text to fill the space (up or down)
+        float scalingFactor = Math.Min(targetWidth / size.Width, targetHeight / size.Height);
+
+        // Create a new font
+        Font scaledFont = new(font, scalingFactor * font.Size);
+
+        PointF center = new(imgSize.Width / 2, imgSize.Height / 2);
+        RichTextOptions textOptions = new(scaledFont)
         {
-            using (var img = SixLabors.ImageSharp.Image.Load(inputImageFilePath))
-            {
-                var outputFilePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".png");
-                Font font = SystemFonts.CreateFont("Arial", 10); // for scaling water mark size is largely ignored.
-
-                using (var img2 = img.Clone(ctx => ApplyScalingWaterMarkSimple(ctx, font, "Gradio.Net", Color.HotPink, 5)))
-                {
-                    img2.Save(outputFilePath);
-                }
-                return outputFilePath;
-            }
-
-        }
-        static IImageProcessingContext ApplyScalingWaterMarkSimple(IImageProcessingContext processingContext,
-                  Font font,
-                  string text,
-                  Color color,
-                  float padding)
-        {
-            Size imgSize = processingContext.GetCurrentSize();
-
-            float targetWidth = imgSize.Width - (padding * 2);
-            float targetHeight = imgSize.Height - (padding * 2);
-
-            // Measure the text size
-            FontRectangle size = TextMeasurer.MeasureSize(text, new TextOptions(font));
-
-            // Find out how much we need to scale the text to fill the space (up or down)
-            float scalingFactor = Math.Min(targetWidth / size.Width, targetHeight / size.Height);
-
-            // Create a new font
-            Font scaledFont = new Font(font, scalingFactor * font.Size);
-
-            var center = new PointF(imgSize.Width / 2, imgSize.Height / 2);
-            var textOptions = new RichTextOptions(scaledFont)
-            {
-                Origin = center,
-                HorizontalAlignment = HorizontalAlignment.Center,
-                VerticalAlignment = VerticalAlignment.Center
-            };
-            return processingContext.DrawText(textOptions, text, color);
-        }
+            Origin = center,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+        return processingContext.DrawText(textOptions, text, color);
     }
 }

--- a/demo/LayoutDemo.cs
+++ b/demo/LayoutDemo.cs
@@ -1,55 +1,52 @@
 ﻿using Gradio.Net;
-using System.Reflection.Emit;
-using static System.Formats.Asn1.AsnWriter;
 
-namespace demo
+namespace demo;
+
+public static class LayoutDemo
 {
-    public static class LayoutDemo
+    public static async Task Create()
     {
-        public static async Task Create()
+        gr.Markdown("# Layout Demo");
+
+        gr.Markdown("## Row/Column");
+        using (gr.Row())
         {
-            gr.Markdown("# Layout Demo");
-
-            gr.Markdown("## Row/Column");
-            using (gr.Row())
+            using (gr.Column(scale: 1))
             {
-                using (gr.Column(scale: 1))
-                {
-                    var text1 = gr.Textbox();
-                    var text2 = gr.Textbox();
-                }
-
-                using (gr.Column(scale: 4))
-                {
-                    var btn1 = gr.Button("Button 1");
-                    var btn2 = gr.Button("Button 2");
-                }
+                Textbox text1 = gr.Textbox();
+                Textbox text2 = gr.Textbox();
             }
 
-            gr.Markdown("## Tab");
-            using (gr.Tab("Lion"))
+            using (gr.Column(scale: 4))
             {
-                gr.Textbox("lion");
-                gr.Button("New Lion");
+                Button btn1 = gr.Button("Button 1");
+                Button btn2 = gr.Button("Button 2");
             }
-            using (gr.Tab("Tiger"))
-            {
-                gr.Textbox("tiger");
-                gr.Button("New Tiger");
-            }
+        }
 
-            gr.Markdown("## Group");
-            using (gr.Group())
-            {
-                gr.Textbox(label: "First");
-                gr.Textbox(label: "Last");
-            }
+        gr.Markdown("## Tab");
+        using (gr.Tab("Lion"))
+        {
+            gr.Textbox("lion");
+            gr.Button("New Lion");
+        }
+        using (gr.Tab("Tiger"))
+        {
+            gr.Textbox("tiger");
+            gr.Button("New Tiger");
+        }
 
-            gr.Markdown("## Accordion");
-            using (gr.Accordion("See Details"))
-            {
-                gr.Markdown("lorem ipsum");
-            }
+        gr.Markdown("## Group");
+        using (gr.Group())
+        {
+            gr.Textbox(label: "First");
+            gr.Textbox(label: "Last");
+        }
+
+        gr.Markdown("## Accordion");
+        using (gr.Accordion("See Details"))
+        {
+            gr.Markdown("lorem ipsum");
         }
     }
 }

--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -1,9 +1,5 @@
 using demo;
 using Gradio.Net;
-using SixLabors.Fonts;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Drawing.Processing;
-using SixLabors.ImageSharp.Processing;
 
 //var builder = WebApplication.CreateBuilder(args);
 //builder.Services.AddGradio();
@@ -18,7 +14,7 @@ App.Launch(await CreateBlocks());
 
 async Task<Blocks> CreateBlocks()
 {
-    using (var blocks = gr.Blocks())
+    using (Blocks blocks = gr.Blocks())
     {
         await FirstDemo.Create();
 

--- a/demo/ProgressDemo.cs
+++ b/demo/ProgressDemo.cs
@@ -1,29 +1,27 @@
 ﻿using Gradio.Net;
-using System.Reflection.Emit;
 
-namespace demo
+namespace demo;
+
+public static class ProgressDemo
 {
-    public static class ProgressDemo
+    public static async Task Create()
     {
-        public static async Task Create()
-        {
-            gr.Markdown("# Progress Demo");
+        gr.Markdown("# Progress Demo");
 
-            var load = gr.Button("Load");
-            var label = gr.Label(label: "Loader");
-            load.Click(LoadSet, outputs: new[] { label });
-        }
+        Button load = gr.Button("Load");
+        Label label = gr.Label(label: "Loader");
+        load.Click(LoadSet, outputs: [label]);
+    }
 
-        static async Task<Output> LoadSet(Input input)
+    static async Task<Output> LoadSet(Input input)
+    {
+        const int count = 24;
+        input.Progress = gr.Progress(count);
+        for (int i = 0; i < count; i++)
         {
-            const int count = 24;
-            input.Progress = gr.Progress(count);
-            for (int i = 0; i < count; i++)
-            {
-                input.Progress.Report(i, desc: "Loading...");
-                await Task.Delay(100);
-            }
-            return gr.Output("Loaded");
+            input.Progress.Report(i, desc: "Loading...");
+            await Task.Delay(100);
         }
+        return gr.Output("Loaded");
     }
 }


### PR DESCRIPTION
* 避免使用 `var`，改用明确的类型以提高代码可读性和可维护性。
* 移除了未引用的命名空间以保持代码整洁。
* 由于前面使用了显式类型，因此省略了 `new` 后面的类型。
* 优先使用文件级别命名空间（file-scoped namespace）来减小嵌套层级。
* 对数组的声明形式进行了更新，采用了C# 12引入的 `[]` 语法。

## English
* Avoid using `var` and instead use explicit types to enhance code readability and maintainability.
* Removed unused namespaces to keep the code clean.
* Omitted the type after `new` since explicit types are used upfront.
* Prefer using file-scoped namespaces to reduce nesting levels.
* Updated array declarations to use the C# 12 `[]` syntax.
