### PR TITLE
include symbols on release

### DIFF
--- a/Gradio.Net/Gradio.Net.csproj
+++ b/Gradio.Net/Gradio.Net.csproj
@@ -5,7 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
- 
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
  
   </PropertyGroup>
 


### PR DESCRIPTION
在发布NuGet包时包含符号包（Symbol Package，通常是`.snupkg`文件）有几个明显的好处：

1. **调试的便利性**：
   - 符号包包含调试符号（PDB文件），允许开发人员在使用你的NuGet包时能够进行更详细的调试。即使是Release模式下，也能通过这些符号查看调用栈、变量值等调试信息，帮助更快地找出问题的根源。

2. **代码调试增强**：
   - 符号文件与源代码关联，可以通过诸如Source Link这样的工具在调试时自动加载源代码。这意味着开发人员在调试时可以直接查看和单步执行你包的源代码，而不只是看到反汇编代码或者仅仅是函数签名。

3. **性能和优化**：
   - 符号包不会影响运行时的性能，因为这些符号仅用于调试，并不在运行时加载。你可以在不影响最终应用程序性能的情况下提供完整的调试信息。

4. **维护和支持**：
   - 在需要排查和解决生产问题时，符号包大大简化了定位问题的过程。开发团队可以更快地复现和修复问题，提升了维护效率。

5. **回溯和历史调试**：
   - 通过符号包，开发人员可以调试特定版本的代码，即使这些代码在后续版本中发生了变化，仍然可以回到特定版本进行调试。

6. **提高开发者体验**：
   - 提供符号包展示了对开发者体验的关注和重视，增强了使用你库的开发人员的工作效率。更好的调试信息减少了开发者的困惑和对于库的猜测，这有助于提高库的口碑和使用频率。

综合来看，通过在发布NuGet包时包含`.snupkg`文件，可以大幅提升库的可调试性和易用性，帮助使用该库的开发者更加高效地工作，同时也能为维护者节省大量的时间和精力。